### PR TITLE
Reduce network fetches

### DIFF
--- a/devops/girder/Dockerfile
+++ b/devops/girder/Dockerfile
@@ -1,8 +1,8 @@
 FROM girder/girder:latest-py3
 
 WORKDIR /src
-RUN git clone https://github.com/girder/large_image.git
+RUN git clone https://github.com/girder/large_image.git --branch nd2-source
 WORKDIR /src/large_image
-RUN pip install -e . -e girder/. -e girder_annotation/. -e tasks/.[girder] -e sources/tiff -e sources/ometiff -e sources/pil -e sources/openslide -e sources/openjpeg --find-links https://girder.github.io/large_image_wheels
+RUN pip install -e . -rrequirements-dev.txt --find-links https://girder.github.io/large_image_wheels
 
 RUN girder build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache 2.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "vue-cli-service serve --host 0.0.0.0",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "test": "npm run lint && npm run build"

--- a/src/components/ContrastHistogram.vue
+++ b/src/components/ContrastHistogram.vue
@@ -115,7 +115,8 @@ function roundAbs(v: number) {
   return Math.round(v);
 }
 
-const THROTTLE = 250; // ms
+// This is debounced elsewhere
+const THROTTLE = 1; // ms
 
 @Component({
   components: {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -87,11 +87,16 @@ export default class ImageViewer extends Vue {
         if (tile.image.src && tile.image.complete) {
           this.ready.push(tile.url);
         } else {
-          tile.image.onload = () => {
+          const tileImage = tile.image;
+          const previousOnload = tileImage.onload;
+          tile.image.onload = (event) => {
             // not just loaded but also decoded
             tile.image.decode().then(() => {
               this.ready.push(tile.url);
             });
+            if (previousOnload) {
+              previousOnload.call(tileImage, event);
+            }
           };
         }
       });

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -63,7 +63,8 @@ export default class ImageViewer extends Vue {
 
   get readyPercentage() {
     const total = this.imageStack.reduce((acc, d) => acc + d.length, 0);
-    const loaded = this.ready.length;
+    const urls = this.imageStack.reduce<string[]>((acc, d) => acc.concat(d.map(i => i.url)), []);
+    const loaded = this.ready.filter(u => urls.indexOf(u) >= 0).length;
     return Math.round((100.0 * loaded) / total);
   }
 

--- a/src/components/ValueSlider.vue
+++ b/src/components/ValueSlider.vue
@@ -44,6 +44,9 @@ export default class ValueSlider extends Vue {
   }
 
   set slider(value: number) {
+    if (value == this.internalValue) {
+      return;
+    }
     this.internalValue = value;
     this.$emit("input", value);
   }

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -106,7 +106,7 @@ export default class GirderAPI {
     const o: Readonly<IHistogramOptions> = Object.assign(
       {
         frame: 0,
-        bins: 128,
+        bins: 512,
         width: 2048,
         height: 2048,
         resample: false
@@ -118,7 +118,7 @@ export default class GirderAPI {
       .get(`item/${toId(item)}/tiles/histogram`, {
         params: o
       })
-      .then(r => r.data[0]); // TODO why is this an array?
+      .then(r => r.data[0]); // TODO deal with multiple channel data
   }
 
   private getItems(folderId: string): Promise<IGirderItem[]> {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -509,7 +509,7 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
   tiles.forEach((tile, i) => {
     const item = items[i]!;
     tile.frames.forEach((frame, j) => {
-      const t = 0; // disable T for now.  +frame.DeltaT;
+      const t = +frame.TheT;
       const xy = +(frame.IndexXY || 0);
       const z = +(frame.IndexZ !== undefined ? frame.IndexZ : frame.PositionZ);
       const c = +frame.TheC;

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -67,7 +67,7 @@ export default class GirderAPI {
     return url.href;
   }
   wholeRegionUrl(
-    item: string | IGirderItem, 
+    item: string | IGirderItem,
     { frame }: { frame: number },
     style: ITileOptions
   ) {
@@ -257,13 +257,13 @@ export default class GirderAPI {
           }
         }
       };
-      oldImage.onload = (event) => {
+      oldImage.onload = event => {
         if (previousOnload) {
           previousOnload.call(oldImage, event);
         }
         localSetSource(event);
       };
-      oldImage.onerror = (event) => {
+      oldImage.onerror = event => {
         if (previousOnerror) {
           previousOnerror.call(oldImage, event);
         }
@@ -286,7 +286,7 @@ export default class GirderAPI {
     const style = toStyle(color, contrast, hist);
 
     images.forEach(image => {
-      /* This gets each tile separately, but since we get all of them this is 
+      /* This gets each tile separately, but since we get all of them this is
        * less efficient than just getting the entire image at once.  There is
        * some potential parallelization speed up, but its benefit is lost in
        * other inefficiencies.
@@ -318,7 +318,11 @@ export default class GirderAPI {
         }
       }
       */
-      const url = this.wholeRegionUrl(image.item, {frame: image.frameIndex}, style);
+      const url = this.wholeRegionUrl(
+        image.item,
+        { frame: image.frameIndex },
+        style
+      );
       const oldImage = this.cleanOldImages(url);
 
       resolvedImages.push({
@@ -327,12 +331,7 @@ export default class GirderAPI {
         width: image.sizeX,
         height: image.sizeY,
         url,
-        image: this.loadImage(
-          url,
-          image.sizeX,
-          image.sizeY,
-          oldImage
-        )
+        image: this.loadImage(url, image.sizeX, image.sizeY, oldImage)
       });
 
       // since horizontal tiling only
@@ -447,7 +446,12 @@ interface IOMEInfo {
 // in the end need a function that maps: t,z,c -> to an image (or tiled image) to be loaded which end up to be the frame
 // number of time points
 
-function toKey(z: number | string, zTime: number | string, xy: number | string, c: number | string) {
+function toKey(
+  z: number | string,
+  zTime: number | string,
+  xy: number | string,
+  c: number | string
+) {
   return `z${z}:t${zTime}:xy${xy}:c${c}`;
 }
 

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -231,29 +231,14 @@ export default class GirderAPI {
   private loadImage(
     url: string,
     width: number,
-    height: number,
-    mimeType: string
+    height: number
   ) {
     if (this.imageCache.has(url)) {
       return this.imageCache.get(url)!;
     }
-    // need to go through axios to have the right header flags
     const image = new Image(width, height);
+    image.src = url;
     this.imageCache.set(url, image);
-
-    // load and set the source when done
-    this.client
-      .get(url, {
-        responseType: "arraybuffer"
-      })
-      .then(r => {
-        const buffer = r.data as ArrayBuffer;
-        const blob = new Blob([buffer], {
-          type: mimeType
-        });
-        const blobUrl = URL.createObjectURL(blob);
-        image.src = blobUrl;
-      });
 
     return image;
   }
@@ -293,8 +278,7 @@ export default class GirderAPI {
             image: this.loadImage(
               url,
               image.tileWidth,
-              image.tileHeight,
-              "image/png"
+              image.tileHeight
             )
           });
         }
@@ -312,8 +296,7 @@ export default class GirderAPI {
         image: this.loadImage(
           url,
           image.sizeX,
-          image.sizeY,
-          "image/png"
+          image.sizeY
         )
       });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -521,7 +521,11 @@ export class Main extends VuexModule {
     ) {
       return;
     }
-    if (/^(input|textarea|select)$/.test((document!.activeElement!.tagName || '').toLowerCase())) {
+    if (
+      /^(input|textarea|select)$/.test(
+        (document!.activeElement!.tagName || "").toLowerCase()
+      )
+    ) {
       return;
     }
     this.toggleLayer(hotKey - 1);
@@ -597,7 +601,13 @@ export class Main extends VuexModule {
       if (!this.dataset || !this.configuration) {
         return Promise.resolve(null);
       }
-      const images = getLayerImages(layer, this.dataset, this.time, this.xy, this.z);
+      const images = getLayerImages(
+        layer,
+        this.dataset,
+        this.time,
+        this.xy,
+        this.z
+      );
       return this.api.getLayerHistogram(images);
     };
   }

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -95,6 +95,8 @@ export interface IDisplayLayer {
   visible: boolean;
 
   contrast: IContrast;
+
+  _histogram?: any | undefined;
 }
 
 export interface IContrast {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "importHelpers": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,


### PR DESCRIPTION
This reduces network fetches when dragging the histogram sliders.  The decreases latency, but still can take up to two image fetches to catch up to the user.

Further improvements will need to improve responsiveness of the server (probably by caching more) and by simulating changes in the client until the server can respond.