### PR TITLE
Streamline the "upload data" page

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       context: ./devops/girder
     command: "-d mongodb://mongodb:27017/girder --host 0.0.0.0"
     ports:
-      - "8080:8080"
+      - "${GIRDER_PORT-8080}:8080"
     links:
       - mongodb
       # - rabbitmq

--- a/package-lock.json
+++ b/package-lock.json
@@ -1398,9 +1398,9 @@
       }
     },
     "@girder/components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@girder/components/-/components-2.0.7.tgz",
-      "integrity": "sha512-2ntS3KXvPKGVPWILdsntjVB30zSuXTjkZ8Iu+h4gJDeCeG7nMp07G/psBmQERPpNpn4v/dkZbX6PKJhvO34zbQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@girder/components/-/components-2.1.0.tgz",
+      "integrity": "sha512-wGwvDMCJMUk9rXaxD1UVvDb3hgV2nEUnXRByKzNPJoDOJXsrFPr3e4x86kRMjzsqiSx3o9DF6YOdKczfhnUzLg==",
       "requires": {
         "@mdi/font": "^3.5.95",
         "axios": "^0.18.1",
@@ -1414,9 +1414,9 @@
       },
       "dependencies": {
         "vuetify": {
-          "version": "2.2.13",
-          "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.13.tgz",
-          "integrity": "sha512-wzJmsyySCNdI/CJNTRbTwaPYJO0sAehUSW1R8GaMHjm9z4j2dK5bBrTv4aiG+n1K7Qc9RoYffzJZn0DSLAkSQw=="
+          "version": "2.2.15",
+          "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.15.tgz",
+          "integrity": "sha512-okz+Q7YfCkLLJsxdldlYWUHcbRX/G+fo/0zSS3rXU+Ir76sxZzIOkSsqox1exFWQJn1PqA0itiHR0QTWygv8VA=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1411,13 +1411,6 @@
         "vue": "^2.6.10",
         "vue-async-computed": "^3.4.1",
         "vuetify": "^2.2.4"
-      },
-      "dependencies": {
-        "vuetify": {
-          "version": "2.2.15",
-          "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.15.tgz",
-          "integrity": "sha512-okz+Q7YfCkLLJsxdldlYWUHcbRX/G+fo/0zSS3rXU+Ir76sxZzIOkSsqox1exFWQJn1PqA0itiHR0QTWygv8VA=="
-        }
       }
     },
     "@hapi/address": {
@@ -17753,9 +17746,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.1.12.tgz",
-      "integrity": "sha512-xMaEX9pz/9bdV0jecuvINk5FD43bUkzfeLKfvrwBu0qroLTpLCdc7mZ7AURAxR5mVmgjqR9BFc7qRtQHA1Lq0Q=="
+      "version": "2.2.17",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.17.tgz",
+      "integrity": "sha512-I2CrVFQSfh1FGgqCdjQYCmfVXILmNAc/6GlN6KthYcrSX5O6oax7j3Opnvfqw5YAoWLU7jS4UwuyNOWid/Y4jA=="
     },
     "vuetify-loader": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "vue-property-decorator": "^8.3.0",
     "vue-resize": "^0.4.5",
     "vue-router": "^3.1.3",
-    "vuetify": "^2.1.12",
+    "vuetify": "^2.2.4",
     "vuex": "^3.1.2",
     "vuex-module-decorators": "^0.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run lint && npm run build"
   },
   "dependencies": {
-    "@girder/components": "^2.0.7",
+    "@girder/components": "^2.1.0",
     "@types/d3-color": "^1.2.2",
     "@types/d3-drag": "^1.2.3",
     "@types/d3-scale": "^2.1.1",

--- a/src/layout/Menu.vue
+++ b/src/layout/Menu.vue
@@ -13,15 +13,7 @@
         <v-icon>mdi-plus-circle</v-icon>
       </v-list-item-action>
       <v-list-item-content>
-        <v-list-item-title>Upload New Data</v-list-item-title>
-      </v-list-item-content>
-    </v-list-item>
-    <v-list-item :to="{ name: 'importdataset' }" v-if="store.isLoggedIn">
-      <v-list-item-action>
-        <v-icon>mdi-plus-circle</v-icon>
-      </v-list-item-action>
-      <v-list-item-content>
-        <v-list-item-title>Use Existing Data</v-list-item-title>
+        <v-list-item-title>Upload Data</v-list-item-title>
       </v-list-item-content>
     </v-list-item>
     <v-list-item

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -2,12 +2,12 @@ import { vuetifyConfig } from "@/girder";
 import { merge } from "lodash-es";
 import Vue from "vue";
 import Vuetify from "vuetify/lib";
-import { VuetifyPreset } from "vuetify/types/presets";
+import { VuetifyPreset } from "vuetify/types/services/presets";
 import Persister from "@/store/Persister";
 
 Vue.use(Vuetify);
 
-const custom: Partial<VuetifyPreset> = {
+const custom = {
   theme: {
     dark: Persister.get("theme", "dark") === "dark"
   }

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -50,7 +50,9 @@ export default class GirderAPI {
 
   async getUserPublicFolder(): Promise<IGirderFolder> {
     const me = await this.client.get("user/me");
-    const result = await this.client.get(`folder?parentType=user&parentId=${me.data._id}&name=Public`);
+    const result = await this.client.get(
+      `folder?parentType=user&parentId=${me.data._id}&name=Public`
+    );
     return result.data.length > 0 ? result.data[0] : null;
   }
 

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -50,7 +50,8 @@ export default class GirderAPI {
 
   async getUserPublicFolder(): Promise<IGirderFolder> {
     const me = await this.client.get("user/me");
-    return this.client.get(`folder?parentType=user&parentId=${me.data._id}&name=Public`);
+    const result = await this.client.get(`folder?parentType=user&parentId=${me.data._id}&name=Public`);
+    return result.data.length > 0 ? result.data[0] : null;
   }
 
   getFiles(item: string | IGirderItem): Promise<IGirderFile[]> {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -47,6 +47,12 @@ export default class GirderAPI {
   getFolder(folderId: string): Promise<IGirderFolder> {
     return this.client.get(`folder/${folderId}`).then(r => r.data);
   }
+
+  async getUserPublicFolder(): Promise<IGirderFolder> {
+    const me = await this.client.get("user/me");
+    return this.client.get(`folder?parentType=user&parentId=${me.data._id}&name=Public`);
+  }
+
   getFiles(item: string | IGirderItem): Promise<IGirderFile[]> {
     return this.client.get(`item/${toId(item)}/files`).then(r => r.data);
   }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -56,14 +56,7 @@
         :to="{ name: 'newdataset' }"
         :disabled="!store.isLoggedIn"
       >
-        Upload New Data
-      </v-btn>
-      <v-btn
-        color="primary"
-        :to="{ name: 'importdataset' }"
-        :disabled="!store.isLoggedIn"
-      >
-        Use Existing Data
+        Upload Data
       </v-btn>
     </div>
   </v-container>

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -53,6 +53,14 @@ import { IGirderSelectAble } from "@/girder";
 import GirderLocationChooser from "@/components/GirderLocationChooser.vue";
 import { IDataset } from "@/store/model";
 
+interface FileUpload {
+  file: File;
+}
+
+type GWCUpload = Vue & {
+  startUpload(): any;
+};
+
 function basename(filename: string): string {
   const components = filename.split(".");
   return components.length > 1
@@ -101,7 +109,7 @@ export default class NewDataset extends Vue {
   readonly store = store;
 
   valid = false;
-  files = [];
+  files = [] as FileUpload[];
   name = "";
   description = "";
 
@@ -170,10 +178,10 @@ export default class NewDataset extends Vue {
 
     await Vue.nextTick();
 
-    this.$refs.uploader.startUpload();
+    (this.$refs.uploader as GWCUpload).startUpload();
   }
 
-  filesChanged(files) {
+  filesChanged(files: FileUpload[]) {
     this.files = files;
 
     if (this.name === "" && files.length > 0) {

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -18,6 +18,7 @@
         <v-subheader>Images</v-subheader>
         <girder-upload
           :dest="path"
+          startButtonText=""
           @done="uploadDone = true"
         />
       </template>

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -19,7 +19,8 @@
         <girder-upload
           ref="uploader"
           :dest="path"
-          startButtonText=""
+          hideStartButton
+          hideHeadline
           @done="uploadDone = true"
         />
       </template>

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -13,22 +13,6 @@
         label="Description"
         :readonly="pageTwo"
       />
-      <v-text-field
-        :value="pathName"
-        label="Path"
-        readonly
-        required
-        placeholder="Choose destination folder..."
-        :rules="rules"
-      >
-        <template #append>
-          <girder-location-chooser
-            v-model="path"
-            title="Select a Destination Folder"
-            :allowNewFolder="true"
-          />
-        </template>
-      </v-text-field>
 
       <template v-if="dataset != null">
         <v-subheader>Images</v-subheader>
@@ -96,6 +80,10 @@ export default class NewDataset extends Vue {
 
   get rules() {
     return [(v: string) => v.trim().length > 0 || `value is required`];
+  }
+
+  async mounted() {
+    this.path = await this.store.api.getUserPublicFolder();
   }
 
   submit() {

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -44,6 +44,17 @@
         >
       </div>
     </v-form>
+
+    <v-alert
+      v-if="failedDataset"
+      text
+      type="error"
+    >
+      Could not create dataset <strong>{{ failedDataset }}</strong>. This might
+      happen, for instance, if a dataset by that name already exists. Please
+      update the dataset name field and try again.
+    </v-alert>
+
   </v-container>
 </template>
 <script lang="ts">
@@ -109,6 +120,7 @@ export default class NewDataset extends Vue {
   readonly store = store;
 
   valid = false;
+  failedDataset = "";
   files = [] as FileUpload[];
   name = "";
   description = "";
@@ -173,6 +185,13 @@ export default class NewDataset extends Vue {
       description: this.description,
       path: this.path!
     });
+
+    if (this.dataset === null) {
+      this.failedDataset = this.name;
+      return;
+    }
+
+    this.failedDataset = "";
 
     this.path = this.dataset!._girder;
 

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -55,7 +55,9 @@ import { IDataset } from "@/store/model";
 
 function basename(filename: string): string {
   const components = filename.split(".");
-  return components.length > 1 ? components.slice(0, -1).join(".") : components[0];
+  return components.length > 1
+    ? components.slice(0, -1).join(".")
+    : components[0];
 }
 
 function findCommonPrefix(strings: string[]): string {
@@ -68,7 +70,10 @@ function findCommonPrefix(strings: string[]): string {
 
   // Get the minimum length of all the strings; the common prefix cannot be
   // longer than this.
-  const minLength = strings.reduce((acc, cur) => Math.min(acc, cur.length), Infinity);
+  const minLength = strings.reduce(
+    (acc, cur) => Math.min(acc, cur.length),
+    Infinity
+  );
 
   // Sweep through the first string, and compare the letter found in each
   // position with the letter at that position for all the strings. Stop when an
@@ -123,9 +128,7 @@ export default class NewDataset extends Vue {
   }
 
   get recommendedName() {
-    const {
-      files,
-    } = this;
+    const { files } = this;
 
     // If there aren't any files selected yet, return a blank string.
     if (files.length === 0) {
@@ -144,7 +147,7 @@ export default class NewDataset extends Vue {
     if (prefix.length > 0) {
       return prefix;
     } else {
-      return basename(files[0].file.name)
+      return basename(files[0].file.name);
     }
   }
 

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -63,7 +63,7 @@ export default class NewDataset extends Vue {
   readonly store = store;
 
   valid = false;
-  filesSelected = false;
+  files = [];
   name = "";
   description = "";
 
@@ -83,6 +83,10 @@ export default class NewDataset extends Vue {
 
   get rules() {
     return [(v: string) => v.trim().length > 0 || `value is required`];
+  }
+
+  get filesSelected() {
+    return this.files.length > 0;
   }
 
   async mounted() {
@@ -108,7 +112,7 @@ export default class NewDataset extends Vue {
   }
 
   filesChanged(files) {
-    this.filesSelected = files.length > 0;
+    this.files = files;
   }
 }
 </script>

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -35,20 +35,14 @@
           @click="submit"
           >Upload
         </v-btn>
-
       </div>
     </v-form>
 
-    <v-alert
-      v-if="failedDataset"
-      text
-      type="error"
-    >
-      Could not create dataset <strong>{{ failedDataset }}</strong>. This might
-      happen, for instance, if a dataset by that name already exists. Please
-      update the dataset name field and try again.
+    <v-alert v-if="failedDataset" text type="error">
+      Could not create dataset <strong>{{ failedDataset }}</strong
+      >. This might happen, for instance, if a dataset by that name already
+      exists. Please update the dataset name field and try again.
     </v-alert>
-
   </v-container>
 </template>
 <script lang="ts">
@@ -212,7 +206,7 @@ export default class NewDataset extends Vue {
     this.hideUploader = true;
 
     this.$router.push({
-      name: 'dataset',
+      name: "dataset",
       params: {
         id: this.dataset!.id
       }

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -17,6 +17,7 @@
       <template>
         <v-subheader>Images</v-subheader>
         <girder-upload
+          ref="uploader"
           :dest="path"
           startButtonText=""
           @done="uploadDone = true"
@@ -25,7 +26,7 @@
 
       <div class="button-bar">
         <v-btn
-          :disabled="!valid"
+          :disabled="!valid || files.length === 0"
           color="success"
           class="mr-4"
           @click="submit"
@@ -80,6 +81,10 @@ export default class NewDataset extends Vue {
 
   get rules() {
     return [(v: string) => v.trim().length > 0 || `value is required`];
+  }
+
+  get files() {
+    return this.$refs.uploader.files;
   }
 
   async mounted() {

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -1,6 +1,16 @@
 <template>
   <v-container>
     <v-form v-model="valid">
+      <girder-upload
+        v-if="path"
+        ref="uploader"
+        :dest="path"
+        hideStartButton
+        hideHeadline
+        @filesChanged="filesChanged"
+        @done="uploadDone = true"
+      />
+
       <v-text-field
         v-model="name"
         label="Name"
@@ -8,23 +18,12 @@
         :rules="rules"
         :readonly="pageTwo"
       />
+
       <v-textarea
         v-model="description"
         label="Description"
         :readonly="pageTwo"
       />
-
-      <template v-if="path">
-        <v-subheader>File(s)</v-subheader>
-        <girder-upload
-          ref="uploader"
-          :dest="path"
-          hideStartButton
-          hideHeadline
-          @filesChanged="filesChanged"
-          @done="uploadDone = true"
-        />
-      </template>
 
       <div class="button-bar">
         <v-btn

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -174,7 +174,7 @@ export default class NewDataset extends Vue {
       path: this.path!
     });
 
-    this.path = this.dataset._girder;
+    this.path = this.dataset!._girder;
 
     await Vue.nextTick();
 

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -30,7 +30,7 @@
           class="mr-4"
           @click="submit"
           v-if="dataset == null"
-          >Create</v-btn
+          >Upload</v-btn
         >
         <v-btn
           :disabled="!uploadDone"

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -15,7 +15,7 @@
       />
 
       <template>
-        <v-subheader>Images</v-subheader>
+        <v-subheader>File(s)</v-subheader>
         <girder-upload
           ref="uploader"
           :dest="path"

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -14,11 +14,11 @@
         :readonly="pageTwo"
       />
 
-      <template v-if="dataset != null">
+      <template>
         <v-subheader>Images</v-subheader>
         <girder-upload
           accept=".ome.tif"
-          :dest="dataset._girder"
+          :dest="path"
           @done="uploadDone = true"
         />
       </template>

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -17,7 +17,6 @@
       <template>
         <v-subheader>Images</v-subheader>
         <girder-upload
-          accept=".ome.tif"
           :dest="path"
           @done="uploadDone = true"
         />

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -23,6 +23,7 @@
         v-model="description"
         label="Description"
         :readonly="pageTwo"
+        rows="2"
       />
 
       <div class="button-bar">

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -14,7 +14,7 @@
         :readonly="pageTwo"
       />
 
-      <template>
+      <template v-if="path">
         <v-subheader>File(s)</v-subheader>
         <girder-upload
           ref="uploader"
@@ -85,7 +85,11 @@ export default class NewDataset extends Vue {
   }
 
   get files() {
-    return this.$refs.uploader.files;
+    let files = [];
+    if (this.$refs.uploader) {
+      files = this.$refs.uploader.files;
+    }
+    return files;
   }
 
   async mounted() {


### PR DESCRIPTION
This PR attempts to make the UX around selecting data for upload more intuitive and streamlined.

The process looks like this:
1. The user first selects a file or files to upload.
2. The interface automatically selects a reasonable name for the dataset, which the user can choose to edit.
3. The user can optionally enter a description of the dataset.

There is no longer a need to first select a place to upload the data files to, eliminating the necessary two-step process that was in place before.

Depends on #44 
