### PR TITLE
Remove branch specifier from Girder Dockerfile

### DIFF
--- a/devops/girder/Dockerfile
+++ b/devops/girder/Dockerfile
@@ -1,7 +1,7 @@
 FROM girder/girder:latest-py3
 
 WORKDIR /src
-RUN git clone https://github.com/girder/large_image.git --branch nd2-source
+RUN git clone https://github.com/girder/large_image.git
 WORKDIR /src/large_image
 RUN pip install -e . -rrequirements-dev.txt --find-links https://girder.github.io/large_image_wheels
 


### PR DESCRIPTION
This fixes the Dockerfile in light of the `nd2-source` branch having been merged to master.