### PR TITLE
Display channel names in viewer layer controls

### DIFF
--- a/devops/girder/Dockerfile
+++ b/devops/girder/Dockerfile
@@ -1,7 +1,7 @@
 FROM girder/girder:latest-py3
 
 WORKDIR /src
-RUN git clone https://github.com/girder/large_image.git
+RUN git clone https://github.com/girder/large_image.git -b standardize-frame-metadata
 WORKDIR /src/large_image
 RUN pip install -e . -rrequirements-dev.txt --find-links https://girder.github.io/large_image_wheels
 

--- a/devops/girder/Dockerfile
+++ b/devops/girder/Dockerfile
@@ -1,7 +1,7 @@
 FROM girder/girder:latest-py3
 
 WORKDIR /src
-RUN git clone https://github.com/girder/large_image.git -b standardize-frame-metadata
+RUN git clone https://github.com/girder/large_image.git
 WORKDIR /src/large_image
 RUN pip install -e . -rrequirements-dev.txt --find-links https://girder.github.io/large_image_wheels
 

--- a/src/components/DisplayLayer.vue
+++ b/src/components/DisplayLayer.vue
@@ -73,7 +73,7 @@
           v-for="(channel, index) in channels"
           :key="index"
           :value="index"
-          :label="channel.toString()"
+          :label="channelName(channel)"
         />
       </v-radio-group>
       <display-slice
@@ -130,6 +130,14 @@ export default class DisplayLayer extends Vue {
 
   get channels() {
     return this.store.dataset ? this.store.dataset.channels : [];
+  }
+
+  channelName(channel: number): string {
+    let result = channel.toString();
+    if (this.store.dataset) {
+      result = this.store.dataset.channelNames.get(channel) || result;
+    }
+    return result;
   }
 
   get visible() {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -542,11 +542,13 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
 
     tile.frames.forEach((frame, j) => {
       const t = metadata.t !== null ? metadata.t : frame.IndexT;
-      const xy = metadata.xy !== null ? metadata.xy : (frame.IndexXY || 0);
+      const xy = metadata.xy !== null ? metadata.xy : frame.IndexXY || 0;
       const z =
         metadata.z !== null
           ? metadata.z
-          : (frame.IndexZ !== undefined ? frame.IndexZ : frame.PositionZ);
+          : frame.IndexZ !== undefined
+          ? frame.IndexZ
+          : frame.PositionZ;
       const metadataChannel =
         channelInt.size > 1 ? channelInt.get(metadata.chan) : undefined;
       const c =
@@ -621,7 +623,7 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
   // console.log(zValues, zTime, channels);
 
   // Create a map of channel names for use in display.
-  const channelNames = new Map<number, string>();;
+  const channelNames = new Map<number, string>();
   if (frameChannel.channels === undefined) {
     for (const entry of channelInt) {
       channelNames.set(entry[1], entry[0]!);

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -543,7 +543,7 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
           ? metadata.z
           : +(frame.IndexZ !== undefined ? frame.IndexZ : frame.PositionZ);
       const metadataChannel = channelInt.get(metadata.chan);
-      const c = metadataChannel !== undefined ? metadataChannel : +frame.TheC;
+      const c = metadataChannel !== undefined ? metadataChannel : (isNaN(+frame.TheC) ? j : +frame.TheC);
       if (zs.has(z)) {
         zs.get(z)!.add(t);
       } else {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -492,6 +492,7 @@ export interface ITileMeta {
   tileHeight: number;
   frames: IFrameInfo[];
   omeinfo: IOMEInfo;
+  channels: string[];
 }
 
 interface IOMEInfo {
@@ -529,7 +530,7 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
 
   const channelInt = new Map<string | null, number>();
   const lookup = new Map<string, IImage[]>();
-  let frameChannel = {};
+  let frameChannels: string[] | undefined;
   tiles.forEach((tile, i) => {
     const item = items[i]!;
     const metadata = getNumericMetadata(item.name);
@@ -537,8 +538,7 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
       channelInt.set(metadata.chan, channelInt.size);
     }
 
-    frameChannel.channelmap = tile.channelmap;
-    frameChannel.channels = tile.channels;
+    frameChannels = tile.channels;
 
     tile.frames.forEach((frame, j) => {
       const t = metadata.t !== null ? metadata.t : frame.IndexT;
@@ -624,12 +624,12 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
 
   // Create a map of channel names for use in display.
   const channelNames = new Map<number, string>();
-  if (frameChannel.channels === undefined) {
+  if (frameChannels === undefined) {
     for (const entry of channelInt) {
       channelNames.set(entry[1], entry[0]!);
     }
   } else {
-    frameChannel.channels.forEach((channel, index) => {
+    frameChannels.forEach((channel: string, index: number) => {
       channelNames.set(index, channel);
     });
   }

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -543,7 +543,8 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
         metadata.z !== null
           ? metadata.z
           : +(frame.IndexZ !== undefined ? frame.IndexZ : frame.PositionZ);
-      const metadataChannel = channelInt.get(metadata.chan);
+      const metadataChannel =
+        channelInt.size > 1 ? channelInt.get(metadata.chan) : undefined;
       const c =
         metadataChannel !== undefined
           ? metadataChannel

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -555,7 +555,7 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
         metadataChannel !== undefined
           ? metadataChannel
           : frame.IndexC === undefined
-          ? j
+          ? 0
           : frame.IndexC;
       if (zs.has(z)) {
         zs.get(z)!.add(t);

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -544,7 +544,12 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
           ? metadata.z
           : +(frame.IndexZ !== undefined ? frame.IndexZ : frame.PositionZ);
       const metadataChannel = channelInt.get(metadata.chan);
-      const c = metadataChannel !== undefined ? metadataChannel : (isNaN(+frame.TheC) ? j : +frame.TheC);
+      const c =
+        metadataChannel !== undefined
+          ? metadataChannel
+          : isNaN(+frame.TheC)
+          ? j
+          : +frame.TheC;
       if (zs.has(z)) {
         zs.get(z)!.add(t);
       } else {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -457,6 +457,7 @@ function asDataset(folder: IGirderFolder): IDataset {
     height: 100,
     time: [],
     channels: [],
+    channelNames: new Map<number, string>(),
     images: () => [],
     configurations: []
   };
@@ -609,6 +610,12 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
   const channels = Array.from(cs).sort((a, b) => a - b);
   // console.log(zValues, zTime, channels);
 
+  // Create a map of channel names for use in display.
+  const channelNames = new Map<number, string>();
+  for (const entry of channelInt) {
+    channelNames.set(entry[1], entry[0]!);
+  }
+
   return {
     images: (z: number, zTime: number, xy: number, channel: number) =>
       lookup.get(toKey(z, zTime, xy, channel)) || [],
@@ -616,6 +623,7 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
     z: zValues,
     time: zTime,
     channels,
+    channelNames,
     width,
     height
   };

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -15,9 +15,8 @@ export interface IFrameInfo {
   PositionZ: number;
   IndexXY: number;
   IndexZ: number;
-  TheC: number;
-  TheT: number;
-  TheZ: number;
+  IndexC: number;
+  IndexT: number;
 }
 
 export interface IImage {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -52,6 +52,7 @@ export interface IDataset {
   time: number[][]; // number of time points, within a set of the time points that reflect valid z-time points
   // time for t,z -> time[t][z]
   channels: number[];
+  channelNames: Map<number, string>;
   width: number;
   height: number;
   images(z: number, zTime: number, xy: number, channel: number): IImage[];

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -204,7 +204,14 @@ export default class DatasetInfo extends Vue {
         description: "default configuration"
       });
 
+      if (config === null) {
+        throw new Error("config was null when it shouldn't be");
+      }
+
       const dataset = this.store.dataset;
+      if (dataset === null) {
+        throw new Error("dataset was null when it shouldn't be");
+      }
       const channels = dataset.channels.slice(0, 6);
       const layers = channels.map(() => newLayer(dataset, []));
       const colors = [
@@ -213,7 +220,7 @@ export default class DatasetInfo extends Vue {
         "#0000FF",
         "#00FFFF",
         "#FF00FF",
-        "#FFFF00",
+        "#FFFF00"
       ];
       channels.forEach((c, i) => {
         const layer = layers[i];

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -68,7 +68,7 @@
 <script lang="ts">
 import { Vue, Component } from "vue-property-decorator";
 import store from "@/store";
-import { IDatasetConfiguration } from "../../store/model";
+import { IDatasetConfiguration, newLayer } from "../../store/model";
 
 function formatDate(d: Date): string {
   const year = d.getFullYear();
@@ -203,6 +203,28 @@ export default class DatasetInfo extends Vue {
         name: `default ${formatDate(date)}`,
         description: "default configuration"
       });
+
+      const dataset = this.store.dataset;
+      const channels = dataset.channels.slice(0, 6);
+      const layers = channels.map(() => newLayer(dataset, []));
+      const colors = [
+        "#FF0000",
+        "#00FF00",
+        "#0000FF",
+        "#00FFFF",
+        "#FF00FF",
+        "#FFFF00",
+      ];
+      channels.forEach((c, i) => {
+        const layer = layers[i];
+        layer.channel = c;
+        layer.color = colors[i];
+        layer.name = dataset.channelNames.get(c) || `Channel ${c}`;
+      });
+
+      config.layers = layers;
+      await store.api.updateConfiguration(config);
+
       this.configuration = [config!];
     } catch (err) {
       throw err;

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -218,7 +218,7 @@ export default class DatasetInfo extends Vue {
       channels.forEach((c, i) => {
         const layer = layers[i];
         layer.channel = c;
-        layer.color = colors[i];
+        layer.color = channels.length === 1 ? "#FFFFFF" : colors[i];
         layer.name = dataset.channelNames.get(c) || `Channel ${c}`;
       });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "jsxFactory": "h",
     "noEmit": true,
+    "downlevelIteration": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": ["webpack-env", "vuetify", "vue"],


### PR DESCRIPTION
- The `downlevelIteration` compiler option is needed to allow `for .. of` constructions in the code
- This works by constructing a map of channel numbers to channel names (if those are available), then using this map, with the channel number itself as a fallback, to display the radio button labels for selecting a channel in the viewer's layer controls