### PR TITLE
Draw a "histogram preview" image while changing the histogram bounds

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -235,7 +235,7 @@ export default class ImageViewer extends Vue {
 
     const layers = this.layerStack;
     this.imageStack.forEach((layer, layerIndex) => {
-      layer.forEach((tile, tileIndex) => {
+      layer.forEach(tile => {
         if (!isReady.has(tile.url)) {
           const layerConfig = layers[layerIndex];
           const filterURL = generateFilterURL(

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -37,21 +37,21 @@ import {
 } from "d3-zoom";
 import { IImageTile } from "../store/model";
 
-function generateFilterURL(contrast: { whitePoint: number; blackPoint: number }, color: string, hist): string {
+function generateFilterURL(contrast: { whitePoint: number; blackPoint: number; mode: string }, color: string, hist: { min: number, max: number }): string {
   // Tease out the RGB color levels.
-  const toVal = (s: str) => parseInt(`0x${s}`);
+  const toVal = (s: string) => parseInt(`0x${s}`);
   const red = toVal(color.slice(1, 3));
   const green = toVal(color.slice(3, 5));
   const blue = toVal(color.slice(5, 7));
 
-  const setSlopeIntercept = (id: str, slope: number, intercept: number) => {
-    const el = document.getElementById(id);
+  const setSlopeIntercept = (id: string, slope: number, intercept: number) => {
+    const el = document.getElementById(id)!;
     el.setAttribute("slope", `${slope}`);
     el.setAttribute("intercept", `${intercept}`);
   };
 
-  const setSlopeIntercept2 = (id: str, wp: number, bp: number, level: number) => {
-    const el = document.getElementById(id);
+  const setSlopeIntercept2 = (id: string, wp: number, bp: number, level: number) => {
+    const el = document.getElementById(id)!;
 
     const levelP = level / 255;
     const wpP = wp;
@@ -86,7 +86,7 @@ export default class ImageViewer extends Vue {
 
   private containerDimensions = { width: 100, height: 100 };
 
-  private imageDataStack: ImageData[][] = [];
+  private imageDataStack: IImageTile[][] = [];
 
   readonly zoom = d3Zoom<HTMLElement, any>()
     .on("zoom", () => {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -44,6 +44,7 @@ function generateFilterURL(
 ): string {
   // Tease out the RGB color levels.
   const toVal = (s: string) => parseInt(`0x${s}`);
+
   const red = toVal(color.slice(1, 3));
   const green = toVal(color.slice(3, 5));
   const blue = toVal(color.slice(5, 7));
@@ -246,7 +247,6 @@ export default class ImageViewer extends Vue {
           ) {
             const oldTile = stack[layerIndex][tileIndex];
             const layerConfig = layers[layerIndex];
-            console.log(layerConfig);
             const filterURL = generateFilterURL(
               layerConfig.contrast,
               layerConfig.color,

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -14,7 +14,7 @@
     </div>
     <svg xmlns="http://www.w3.org/2000/svg">
       <defs>
-        <filter id="recolor">
+        <filter id="recolor" color-interpolation-filters="sRGB">
           <feComponentTransfer>
             <feFuncR id="func-r" type="linear" slope="0" intercept="0" />
             <feFuncG id="func-g" type="linear" slope="0" intercept="0" />

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -230,11 +230,10 @@ export default class ImageViewer extends Vue {
 
   private draw(canvas: HTMLCanvasElement) {
     const ctx = canvas.getContext("2d")!;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.globalCompositeOperation = this.store.compositionMode;
 
     const isReady = new Set(this.ready);
-
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
 
     let stack = this.imageDataStack;
     const layers = this.layerStack;
@@ -288,38 +287,6 @@ export default class ImageViewer extends Vue {
         );
       });
     });
-  }
-
-  private drawShadow(canvas: HTMLCanvasElement) {
-    const ctx = canvas.getContext("2d")!;
-
-    const image2 = ctx.getImageData(0, 0, canvas.width, canvas.height);
-
-    const image = new ImageData(
-      Uint8ClampedArray.from(image2.data),
-      canvas.width,
-      canvas.height
-    );
-
-    let d = image.data;
-    for (let i = 0; i < canvas.height; i++) {
-      for (let j = 0; j < canvas.width; j++) {
-        const idx = 4 * (i * canvas.width + j);
-        for (let k = 0; k < 1; k++) {
-          d[idx + k] = 255 - d[idx + k];
-          // d[idx + k] = Math.random() * 255;
-        }
-        // d[idx + 3] = 255;
-      }
-    }
-
-    // ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.putImageData(image, 0, 0);
-
-    // ctx.beginPath();
-    // ctx.rect(20, 20, canvas.width / 2, canvas.height / 3);
-    // ctx.fillStyle = "red";
-    // ctx.fill();
   }
 }
 </script>

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -43,7 +43,7 @@ function generateFilterURL(
   hist: { min: number; max: number }
 ): string {
   // Tease out the RGB color levels.
-  const toVal = (s: string) => parseInt(`0x${s}`);
+  const toVal = (s: string) => parseInt(`0x${s}`) / 255;
 
   const red = toVal(color.slice(1, 3));
   const green = toVal(color.slice(3, 5));
@@ -57,7 +57,7 @@ function generateFilterURL(
   ) => {
     const el = document.getElementById(id)!;
 
-    const levelP = level / 255;
+    const levelP = level;
     const wpP = wp;
     const bpP = bp;
 

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -48,13 +48,7 @@ function generateFilterURL(
   const green = toVal(color.slice(3, 5));
   const blue = toVal(color.slice(5, 7));
 
-  const setSlopeIntercept = (id: string, slope: number, intercept: number) => {
-    const el = document.getElementById(id)!;
-    el.setAttribute("slope", `${slope}`);
-    el.setAttribute("intercept", `${intercept}`);
-  };
-
-  const setSlopeIntercept2 = (
+  const setSlopeIntercept = (
     id: string,
     wp: number,
     bp: number,
@@ -70,18 +64,15 @@ function generateFilterURL(
     el.setAttribute("intercept", `${-(levelP * bpP) / (wpP - bpP)}`);
   };
 
-  const slope = (wp: number, bp: number, level: number) =>
-    (((wp - bp) / 100) * level) / 255;
-
   const scalePoint = (val: number, mode: string) =>
     mode === "absolute" ? (val - hist.min) / (hist.max - hist.min) : val / 100;
 
   const whitePoint = scalePoint(contrast.whitePoint, contrast.mode);
   const blackPoint = scalePoint(contrast.blackPoint, contrast.mode);
 
-  setSlopeIntercept2("func-r", whitePoint, blackPoint, red);
-  setSlopeIntercept2("func-g", whitePoint, blackPoint, green);
-  setSlopeIntercept2("func-b", whitePoint, blackPoint, blue);
+  setSlopeIntercept("func-r", whitePoint, blackPoint, red);
+  setSlopeIntercept("func-g", whitePoint, blackPoint, green);
+  setSlopeIntercept("func-b", whitePoint, blackPoint, blue);
 
   return "#recolor";
 }

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -144,14 +144,18 @@ export default class ImageViewer extends Vue {
     value.forEach(layer => {
       layer.forEach(tile => {
         if (tile.image.src && tile.image.complete) {
-          this.ready.push(tile.url);
+          if (!this.ready.includes(tile.url)) {
+            this.ready.push(tile.url);
+          }
         } else {
           const tileImage = tile.image;
           const previousOnload = tileImage.onload;
           tile.image.onload = event => {
             // not just loaded but also decoded
             tile.image.decode().then(() => {
-              this.ready.push(tile.url);
+              if (!this.ready.includes(tile.url)) {
+                this.ready.push(tile.url);
+              }
             });
             if (previousOnload) {
               previousOnload.call(tileImage, event);

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -253,7 +253,7 @@ export default class ImageViewer extends Vue {
             );
             ctx.filter = `url(${filterURL})`;
             ctx.drawImage(
-              oldTile.image,
+              oldTile.fullImage,
               0,
               0,
               oldTile.width,

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -87,8 +87,6 @@ export default class ImageViewer extends Vue {
 
   private containerDimensions = { width: 100, height: 100 };
 
-  private imageDataStack: IImageTile[][] = [];
-
   readonly zoom = d3Zoom<HTMLElement, any>()
     .on("zoom", () => {
       this.zoomed(d3Event as D3ZoomEvent<HTMLElement, any>);
@@ -235,45 +233,31 @@ export default class ImageViewer extends Vue {
 
     const isReady = new Set(this.ready);
 
-    let stack = this.imageDataStack;
     const layers = this.layerStack;
     this.imageStack.forEach((layer, layerIndex) => {
       layer.forEach((tile, tileIndex) => {
         if (!isReady.has(tile.url)) {
-          if (
-            stack.length > layerIndex &&
-            stack[layerIndex][tileIndex] !== undefined
-          ) {
-            const oldTile = stack[layerIndex][tileIndex];
-            const layerConfig = layers[layerIndex];
-            const filterURL = generateFilterURL(
-              layerConfig.contrast,
-              layerConfig.color,
-              layerConfig._histogram.last
-            );
-            ctx.filter = `url(${filterURL})`;
-            ctx.drawImage(
-              oldTile.fullImage,
-              0,
-              0,
-              oldTile.width,
-              oldTile.height,
-              oldTile.x,
-              oldTile.y,
-              oldTile.width,
-              oldTile.height
-            );
-            ctx.filter = "none";
-          }
+          const layerConfig = layers[layerIndex];
+          const filterURL = generateFilterURL(
+            layerConfig.contrast,
+            layerConfig.color,
+            layerConfig._histogram.last
+          );
+          ctx.filter = `url(${filterURL})`;
+          ctx.drawImage(
+            tile.fullImage,
+            0,
+            0,
+            tile.width,
+            tile.height,
+            tile.x,
+            tile.y,
+            tile.width,
+            tile.height
+          );
+          ctx.filter = "none";
           return;
         }
-
-        if (stack.length <= layerIndex) {
-          stack[layerIndex] = [];
-        }
-
-        stack[layerIndex][tileIndex] = tile;
-
         ctx.drawImage(
           tile.image,
           0,

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -37,7 +37,11 @@ import {
 } from "d3-zoom";
 import { IImageTile } from "../store/model";
 
-function generateFilterURL(contrast: { whitePoint: number; blackPoint: number; mode: string }, color: string, hist: { min: number, max: number }): string {
+function generateFilterURL(
+  contrast: { whitePoint: number; blackPoint: number; mode: string },
+  color: string,
+  hist: { min: number; max: number }
+): string {
   // Tease out the RGB color levels.
   const toVal = (s: string) => parseInt(`0x${s}`);
   const red = toVal(color.slice(1, 3));
@@ -50,7 +54,12 @@ function generateFilterURL(contrast: { whitePoint: number; blackPoint: number; m
     el.setAttribute("intercept", `${intercept}`);
   };
 
-  const setSlopeIntercept2 = (id: string, wp: number, bp: number, level: number) => {
+  const setSlopeIntercept2 = (
+    id: string,
+    wp: number,
+    bp: number,
+    level: number
+  ) => {
     const el = document.getElementById(id)!;
 
     const levelP = level / 255;
@@ -61,11 +70,11 @@ function generateFilterURL(contrast: { whitePoint: number; blackPoint: number; m
     el.setAttribute("intercept", `${-(levelP * bpP) / (wpP - bpP)}`);
   };
 
-  const slope = (wp: number, bp: number, level: number) => ((wp - bp) / 100) * level / 255;
+  const slope = (wp: number, bp: number, level: number) =>
+    (((wp - bp) / 100) * level) / 255;
 
-  const scalePoint = (val: number, mode: string) => mode === "absolute" ?
-    (val - hist.min) / (hist.max - hist.min) :
-    val / 100;
+  const scalePoint = (val: number, mode: string) =>
+    mode === "absolute" ? (val - hist.min) / (hist.max - hist.min) : val / 100;
 
   const whitePoint = scalePoint(contrast.whitePoint, contrast.mode);
   const blackPoint = scalePoint(contrast.blackPoint, contrast.mode);
@@ -240,11 +249,18 @@ export default class ImageViewer extends Vue {
     this.imageStack.forEach((layer, layerIndex) => {
       layer.forEach((tile, tileIndex) => {
         if (!isReady.has(tile.url)) {
-          if (stack.length > layerIndex && stack[layerIndex][tileIndex] !== undefined) {
+          if (
+            stack.length > layerIndex &&
+            stack[layerIndex][tileIndex] !== undefined
+          ) {
             const oldTile = stack[layerIndex][tileIndex];
             const layerConfig = layers[layerIndex];
             console.log(layerConfig);
-            const filterURL = generateFilterURL(layerConfig.contrast, layerConfig.color, layerConfig._histogram.last);
+            const filterURL = generateFilterURL(
+              layerConfig.contrast,
+              layerConfig.color,
+              layerConfig._histogram.last
+            );
             ctx.filter = `url(${filterURL})`;
             ctx.drawImage(
               oldTile.image,
@@ -255,9 +271,9 @@ export default class ImageViewer extends Vue {
               oldTile.x,
               oldTile.y,
               oldTile.width,
-              oldTile.height,
+              oldTile.height
             );
-            ctx.filter = 'none';
+            ctx.filter = "none";
           }
           return;
         }
@@ -288,7 +304,11 @@ export default class ImageViewer extends Vue {
 
     const image2 = ctx.getImageData(0, 0, canvas.width, canvas.height);
 
-    const image = new ImageData(Uint8ClampedArray.from(image2.data), canvas.width, canvas.height);
+    const image = new ImageData(
+      Uint8ClampedArray.from(image2.data),
+      canvas.width,
+      canvas.height
+    );
 
     let d = image.data;
     for (let i = 0; i < canvas.height; i++) {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -172,11 +172,16 @@ export default class ImageViewer extends Vue {
 
   private draw(canvas: HTMLCanvasElement) {
     const ctx = canvas.getContext("2d")!;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.globalCompositeOperation = this.store.compositionMode;
+
+    if (this.ready.length === 0) {
+      this.drawShadow(canvas);
+      return;
+    }
 
     const isReady = new Set(this.ready);
 
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
     this.imageStack.forEach(layer => {
       layer.forEach(tile => {
         if (!isReady.has(tile.url)) {
@@ -195,6 +200,34 @@ export default class ImageViewer extends Vue {
         );
       });
     });
+  }
+
+  private drawShadow(canvas: HTMLCanvasElement) {
+    const ctx = canvas.getContext("2d")!;
+
+    const image2 = ctx.getImageData(0, 0, canvas.width, canvas.height);
+
+    const image = new ImageData(Uint8ClampedArray.from(image2.data), canvas.width, canvas.height);
+
+    let d = image.data;
+    for (let i = 0; i < canvas.height; i++) {
+      for (let j = 0; j < canvas.width; j++) {
+        const idx = 4 * (i * canvas.width + j);
+        for (let k = 0; k < 1; k++) {
+          d[idx + k] = 255 - d[idx + k];
+          // d[idx + k] = Math.random() * 255;
+        }
+        // d[idx + 3] = 255;
+      }
+    }
+
+    // ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.putImageData(image, 0, 0);
+
+    // ctx.beginPath();
+    // ctx.rect(20, 20, canvas.width / 2, canvas.height / 3);
+    // ctx.fillStyle = "red";
+    // ctx.fill();
   }
 }
 </script>

--- a/src/layout/UserMenu.vue
+++ b/src/layout/UserMenu.vue
@@ -23,7 +23,6 @@
             v-model="username"
             name="username"
             label="Username or e-mail"
-            autofocus
             required
             prepend-icon="mdi-account"
           />

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -265,7 +265,6 @@ export default class GirderAPI {
       return this.imageCache.get(url)!;
     }
     const image = new Image(width, height) as HTMLImageElementLocal;
-    image.crossOrigin = "Anonymous";
 
     // Keep the size of the cache under control.
     if (this.imageCache.size === 100) {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -265,6 +265,7 @@ export default class GirderAPI {
       return this.imageCache.get(url)!;
     }
     const image = new Image(width, height) as HTMLImageElementLocal;
+    image.crossOrigin = "Anonymous";
 
     // Keep the size of the cache under control.
     if (this.imageCache.size === 100) {

--- a/src/store/images.ts
+++ b/src/store/images.ts
@@ -67,7 +67,8 @@ export function toStyle(
   contrast: IContrast,
   hist: ITileHistogram | null
 ): ITileOptions {
-  const p = palette(color, 17);
+  // unless we add a gamma function, 2 steps are all that are necessary.
+  const p = palette(color, 2);
   if (contrast.mode === "absolute") {
     return {
       min: contrast.blackPoint,
@@ -75,7 +76,7 @@ export function toStyle(
       palette: p
     };
   }
-  if (hist) {
+  if (hist && (contrast.blackPoint !== 0 || contrast.whitePoint !== 100)) {
     const scale = scaleLinear()
       .domain([0, 100])
       .rangeRound([hist.min, hist.max]);
@@ -85,7 +86,7 @@ export function toStyle(
       palette: p
     };
   }
-  // cannot compute absolute values yet
+  // cannot compute absolute values or they are the min/max
   return {
     min: "min",
     max: "max",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -595,6 +595,17 @@ export class Main extends VuexModule {
       });
   }
 
+  get layerStack(): IImageTile[][] {
+    if (!this.dataset || !this.configuration) {
+      return [];
+    }
+    const ds = this.dataset;
+    const layers = this.configuration.layers;
+
+    return layers
+      .filter(d => d.visible);
+  }
+
   get getLayerHistogram() {
     // need to be like that to be detected as a getter
     return (layer: IDisplayLayer) => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -602,8 +602,7 @@ export class Main extends VuexModule {
     const ds = this.dataset;
     const layers = this.configuration.layers;
 
-    return layers
-      .filter(d => d.visible);
+    return layers.filter(d => d.visible);
   }
 
   get getLayerHistogram() {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -595,7 +595,7 @@ export class Main extends VuexModule {
       });
   }
 
-  get layerStack(): IImageTile[][] {
+  get layerStack(): IDisplayLayer[] {
     if (!this.dataset || !this.configuration) {
       return [];
     }

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -37,6 +37,7 @@ export interface IImageTile {
   height: number;
   url: string;
   image: HTMLImageElement;
+  fullImage: HTMLImageElement;
 }
 
 export interface IDataset {


### PR DESCRIPTION
This shows an estimated preview of the image under the changing histogram during the interval between when the change is made, and when a new, correct image arrives from the server.

It works by saving the last rendered image for each channel, and adjusting the color contrast in that image via an SVG filter applied as a canvas filter.