### PR TITLE
Reduce the number of images fetched.

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -235,7 +235,7 @@ export default class ImageViewer extends Vue {
 
     const layers = this.layerStack;
     this.imageStack.forEach((layer, layerIndex) => {
-      layer.forEach((tile, tileIndex) => {
+      layer.forEach(tile => {
         if (!isReady.has(tile.url)) {
           const layerConfig = layers[layerIndex];
           const filterURL = generateFilterURL(

--- a/src/store/images.ts
+++ b/src/store/images.ts
@@ -67,7 +67,8 @@ export function toStyle(
   contrast: IContrast,
   hist: ITileHistogram | null
 ): ITileOptions {
-  const p = palette(color, 17);
+  // unless we add a gamma function, 2 steps are all that are necessary.
+  const p = palette(color, 2);
   if (contrast.mode === "absolute") {
     return {
       min: contrast.blackPoint,
@@ -75,7 +76,7 @@ export function toStyle(
       palette: p
     };
   }
-  if (hist) {
+  if (hist && (contrast.blackPoint !== 0 || contrast.whitePoint !== 100)) {
     const scale = scaleLinear()
       .domain([0, 100])
       .rangeRound([hist.min, hist.max]);
@@ -85,7 +86,7 @@ export function toStyle(
       palette: p
     };
   }
-  // cannot compute absolute values yet
+  // cannot compute absolute values or they are the min/max
   return {
     min: "min",
     max: "max",


### PR DESCRIPTION
We were fetching a full range image for the histogram preview.  If this is fetched before the histogram, it used query parameters of min: min, max: max.  If fetched after the histogram, it specified numerical values.  This always prefers min/max in the query for full range.

Also, reduce the number of palette steps -- we are using a linear transform, so additional steps are of no benefit (and could introduce mild artifacts for colors that are do not use the full possible range).