### PR TITLE
Don't add an image to the ready list multiple times.

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -144,14 +144,18 @@ export default class ImageViewer extends Vue {
     value.forEach(layer => {
       layer.forEach(tile => {
         if (tile.image.src && tile.image.complete) {
-          this.ready.push(tile.url);
+          if (!this.ready.includes(tile.url)) {
+            this.ready.push(tile.url);
+          }
         } else {
           const tileImage = tile.image;
           const previousOnload = tileImage.onload;
           tile.image.onload = event => {
             // not just loaded but also decoded
             tile.image.decode().then(() => {
-              this.ready.push(tile.url);
+              if (!this.ready.includes(tile.url)) {
+                this.ready.push(tile.url);
+              }
             });
             if (previousOnload) {
               previousOnload.call(tileImage, event);

--- a/src/layout/UserMenu.vue
+++ b/src/layout/UserMenu.vue
@@ -23,7 +23,6 @@
             v-model="username"
             name="username"
             label="Username or e-mail"
-            autofocus
             required
             prepend-icon="mdi-account"
           />


### PR DESCRIPTION
Remove autofocus attribute of user name.

If we want to autofocus something, this isn't the most useful element.  Plus, Chrome 79+ emits a warning about it.