### PR TITLE
Improve the breadcrumbs.

### DIFF
--- a/src/layout/BreadCrumbs.vue
+++ b/src/layout/BreadCrumbs.vue
@@ -2,6 +2,21 @@
   <v-breadcrumbs :items="items" />
 </template>
 
+<style>
+.v-breadcrumbs .v-breadcrumbs__divider {
+  display: none;
+}
+.v-breadcrumbs li:first-child:before {
+  content: "Dataset:";
+  padding-right: 5px;
+}
+.v-breadcrumbs li:last-child:before {
+  content: "Configuration:";
+  padding-left: 15px;
+  padding-right: 5px;
+}
+</style>
+
 <script lang="ts">
 import { Vue, Component } from "vue-property-decorator";
 import store from "@/store";
@@ -13,6 +28,7 @@ export default class BreadCrumbs extends Vue {
   get items() {
     return this.$route.matched
       .filter(m => !m.meta.hidden)
+      .filter(m => m.name !== "view")
       .map(record => {
         const customText = record.meta.text;
         let text = customText


### PR DESCRIPTION
Instead of showing "stemmedia_8well_bottomright_005.nd2 / 2020-02-11 / Explore", this now shows "Dataset: stemmedia_8well_bottomright_005.nd2 Configuration: 2020-02-11".

This resolves #38.

Example, before:
![image](https://user-images.githubusercontent.com/8781639/81973580-4fb35b00-95f2-11ea-8b0e-cc5259fdc8b0.png)
Example, after:
![image](https://user-images.githubusercontent.com/8781639/81973498-36aaaa00-95f2-11ea-9a9c-c6f272ac066a.png)
