### PR TITLE
Improve CSS on switch controls.

### DIFF
--- a/src/components/DisplaySlice.vue
+++ b/src/components/DisplaySlice.vue
@@ -47,6 +47,11 @@
     </template>
   </v-radio-group>
 </template>
+<style>
+.v-input--radio-group--column .v-input--radio-group__input > .v-label {
+  padding-bottom: 2px;
+}
+</style>
 
 <script lang="ts">
 import { Vue, Component, Prop } from "vue-property-decorator";

--- a/src/components/SwitchToggle.vue
+++ b/src/components/SwitchToggle.vue
@@ -23,6 +23,15 @@
     </template>
   </v-switch>
 </template>
+<style>
+.v-input--selection-controls > .v-input__prepend-outer {
+  white-space: nowrap;
+  margin-top: 2px;
+}
+.v-input--selection-controls {
+  margin-top: 8px;
+}
+</style>
 <script lang="ts">
 import { Vue, Component, Prop } from "vue-property-decorator";
 


### PR DESCRIPTION
This fixes the CSS of the two-state switch controls.

Instead of this:
![image](https://user-images.githubusercontent.com/8781639/82244473-4e926e80-990f-11ea-8ee6-57d4c449fc87.png)
it now looks like this:
![image](https://user-images.githubusercontent.com/8781639/82244575-6d910080-990f-11ea-83c0-4575efd98b08.png)
