### PR TITLE
Guard against a layer that doesn't contain an image.

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -42,6 +42,9 @@ function generateFilterURL(
   color: string,
   hist: { min: number; max: number }
 ): string {
+  if (hist === null) {
+    return '';
+  }
   // Tease out the RGB color levels.
   const toVal = (s: string) => parseInt(`0x${s}`) / 255;
 
@@ -247,6 +250,9 @@ export default class ImageViewer extends Vue {
             layerConfig.color,
             layerConfig._histogram.last
           );
+          if (filterURL === '') {
+            return;
+          }
           ctx.filter = `url(${filterURL})`;
           ctx.drawImage(
             tile.fullImage,


### PR DESCRIPTION
If you have a layer with a slice that has an offset, then at the ends of the range, that layer may not have an image.  Don't throw an exception in that case.