### PR TITLE
Add checkboxes to toggle unrolling by XY, Z, and T

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,6 +2011,11 @@
         "@types/babel-types": "*"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
+      "integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g=="
+    },
     "@types/body-parser": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@girder/components": "^2.1.0",
+    "@types/bluebird": "^3.5.32",
     "@types/d3-color": "^1.2.2",
     "@types/d3-drag": "^1.2.3",
     "@types/d3-scale": "^2.1.1",

--- a/src/components/DisplayLayer.vue
+++ b/src/components/DisplayLayer.vue
@@ -81,18 +81,21 @@
         @change="changeProp('xy', $event)"
         label="XY-Slice"
         :max-value="maxXY"
+        v-if="maxXY > 0"
       />
       <display-slice
         :value="value.z"
         @change="changeProp('z', $event)"
         label="Z-Slice"
         :max-value="maxZ"
+        v-if="maxZ > 0"
       />
       <display-slice
         :value="value.time"
         @change="changeProp('time', $event)"
         label="Time-Slice"
         :max-value="maxTime"
+        v-if="maxTime > 0"
       />
       <div class="buttons">
         <v-btn color="warning" small @click="removeLayer">Remove</v-btn>

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -250,7 +250,7 @@ export default class ImageViewer extends Vue {
             layerConfig.color,
             layerConfig._histogram.last
           );
-          if (filterURL === '') {
+          if (filterURL === "") {
             return;
           }
           ctx.filter = `url(${filterURL})`;

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -1,20 +1,11 @@
 <template>
   <div>
     <value-slider v-model="xy" label="XY Value" :min="0" :max="maxXY" />
-    <v-checkbox
-      v-model="splayXY"
-      label="Splay by XY"
-    />
+    <v-checkbox v-model="splayXY" label="Splay by XY" />
     <value-slider v-model="z" label="Z Value" :min="0" :max="maxZ" />
-    <v-checkbox
-      v-model="splayZ"
-      label="Splay by Z"
-    />
+    <v-checkbox v-model="splayZ" label="Splay by Z" />
     <value-slider v-model="time" label="Time Value" :min="0" :max="maxTime" />
-    <v-checkbox
-      v-model="splayT"
-      label="Splay by T"
-    />
+    <v-checkbox v-model="splayT" label="Splay by T" />
     <switch-toggle
       v-model="layerMode"
       label="Layers: "

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -4,19 +4,19 @@
       <value-slider v-model="xy" label="XY Value" :min="0" :max="maxXY" />
       <v-checkbox
         v-model="splayXY"
-        label="Splay by XY"
+        label="Unroll by XY"
         v-if="maxXY > 0 || splayXY"
       />
       <value-slider v-model="z" label="Z Value" :min="0" :max="maxZ" />
       <v-checkbox
         v-model="splayZ"
-        label="Splay by Z"
+        label="Unroll by Z"
         v-if="maxZ > 0 || splayZ"
       />
       <value-slider v-model="time" label="Time Value" :min="0" :max="maxTime" />
       <v-checkbox
         v-model="splayT"
-        label="Splay by T"
+        label="Unroll by T"
         v-if="maxTime > 0 || splayT"
       />
       <switch-toggle

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
     <value-slider v-model="xy" label="XY Value" :min="0" :max="maxXY" />
+    <v-checkbox
+      v-model="splayXY"
+      label="Splay by XY"
+    />
     <value-slider v-model="z" label="Z Value" :min="0" :max="maxZ" />
     <value-slider v-model="time" label="Time Value" :min="0" :max="maxTime" />
     <switch-toggle
@@ -38,7 +42,7 @@
 }
 </style>
 <script lang="ts">
-import { Vue, Component } from "vue-property-decorator";
+import { Vue, Component, Watch } from "vue-property-decorator";
 import ValueSlider from "./ValueSlider.vue";
 import SwitchToggle from "./SwitchToggle.vue";
 import store from "@/store";
@@ -102,6 +106,19 @@ export default class ViewerToolbar extends Vue {
 
   set time(value: number) {
     this.changeQuery("time", value.toString());
+  }
+
+  get splayXY() {
+    return this.store.splayXY;
+  }
+
+  set splayXY(value: boolean) {
+    this.store.setSplayXY(value);
+  }
+
+  @Watch("splayXY")
+  watchSplayXY(value: boolean) {
+    this.store.refreshDataset();
   }
 
   get maxXY() {

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -133,7 +133,7 @@ export default class ViewerToolbar extends Vue {
   }
 
   set splayXY(value: boolean) {
-    this.store.setSplayXY(value);
+    this.changeQuery("unrollXY", value.toString());
   }
 
   @Watch("splayXY")
@@ -147,6 +147,7 @@ export default class ViewerToolbar extends Vue {
 
   set splayZ(value: boolean) {
     this.store.setSplayZ(value);
+    this.changeQuery("unrollZ", value.toString());
   }
 
   @Watch("splayZ")
@@ -159,7 +160,7 @@ export default class ViewerToolbar extends Vue {
   }
 
   set splayT(value: boolean) {
-    this.store.setSplayT(value);
+    this.changeQuery("unrollT", value.toString());
   }
 
   @Watch("splayT")

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -5,19 +5,19 @@
       <v-checkbox
         v-model="splayXY"
         label="Unroll by XY"
-        v-if="maxXY > 0 || splayXY"
+        :disabled="!(maxXY > 0 || splayXY)"
       />
       <value-slider v-model="z" label="Z Value" :min="0" :max="maxZ" />
       <v-checkbox
         v-model="splayZ"
         label="Unroll by Z"
-        v-if="maxZ > 0 || splayZ"
+        :disabled="!(maxZ > 0 || splayZ)"
       />
       <value-slider v-model="time" label="Time Value" :min="0" :max="maxTime" />
       <v-checkbox
         v-model="splayT"
         label="Unroll by T"
-        v-if="maxTime > 0 || splayT"
+        :disabled="!(maxTime > 0 || splayT)"
       />
       <switch-toggle
         v-model="layerMode"

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -2,11 +2,23 @@
   <div>
     <div>
       <value-slider v-model="xy" label="XY Value" :min="0" :max="maxXY" />
-      <v-checkbox v-model="splayXY" label="Splay by XY" />
+      <v-checkbox
+        v-model="splayXY"
+        label="Splay by XY"
+        v-if="maxXY > 0 || splayXY"
+      />
       <value-slider v-model="z" label="Z Value" :min="0" :max="maxZ" />
-      <v-checkbox v-model="splayZ" label="Splay by Z" />
+      <v-checkbox
+        v-model="splayZ"
+        label="Splay by Z"
+        v-if="maxZ > 0 || splayZ"
+      />
       <value-slider v-model="time" label="Time Value" :min="0" :max="maxTime" />
-      <v-checkbox v-model="splayT" label="Splay by T" />
+      <v-checkbox
+        v-model="splayT"
+        label="Splay by T"
+        v-if="maxTime > 0 || splayT"
+      />
       <switch-toggle
         v-model="layerMode"
         label="Layers: "
@@ -125,7 +137,7 @@ export default class ViewerToolbar extends Vue {
   }
 
   @Watch("splayXY")
-  watchSplayXY(value: boolean) {
+  watchSplayXY(_value: boolean) {
     this.store.refreshDataset();
   }
 
@@ -138,7 +150,7 @@ export default class ViewerToolbar extends Vue {
   }
 
   @Watch("splayZ")
-  watchSplayZ(value: boolean) {
+  watchSplayZ(_value: boolean) {
     this.store.refreshDataset();
   }
 
@@ -151,7 +163,7 @@ export default class ViewerToolbar extends Vue {
   }
 
   @Watch("splayT")
-  watchSplayT(value: boolean) {
+  watchSplayT(_value: boolean) {
     this.store.refreshDataset();
   }
 

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -6,7 +6,15 @@
       label="Splay by XY"
     />
     <value-slider v-model="z" label="Z Value" :min="0" :max="maxZ" />
+    <v-checkbox
+      v-model="splayZ"
+      label="Splay by Z"
+    />
     <value-slider v-model="time" label="Time Value" :min="0" :max="maxTime" />
+    <v-checkbox
+      v-model="splayT"
+      label="Splay by T"
+    />
     <switch-toggle
       v-model="layerMode"
       label="Layers: "
@@ -118,6 +126,32 @@ export default class ViewerToolbar extends Vue {
 
   @Watch("splayXY")
   watchSplayXY(value: boolean) {
+    this.store.refreshDataset();
+  }
+
+  get splayZ() {
+    return this.store.splayZ;
+  }
+
+  set splayZ(value: boolean) {
+    this.store.setSplayZ(value);
+  }
+
+  @Watch("splayZ")
+  watchSplayZ(value: boolean) {
+    this.store.refreshDataset();
+  }
+
+  get splayT() {
+    return this.store.splayT;
+  }
+
+  set splayT(value: boolean) {
+    this.store.setSplayT(value);
+  }
+
+  @Watch("splayT")
+  watchSplayT(value: boolean) {
     this.store.refreshDataset();
   }
 

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -403,7 +403,7 @@ export default class GirderAPI {
     let offsetY = 0;
 
     const hist = this.getResolvedLayerHistogram(images);
-    const style = hist ? toStyle(color, contrast, hist) : '';
+    const style = toStyle(color, contrast, hist);
 
     const rowLength = Math.ceil(Math.sqrt(images.length));
 

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -152,7 +152,7 @@ export default class GirderAPI {
     );
   }
 
-  getDataset(id: string, splayXY: boolean): Promise<IDataset> {
+  getDataset(id: string, splayXY: boolean, splayZ: boolean, splayT: boolean): Promise<IDataset> {
     return Promise.all([this.getFolder(id), this.getItems(id)]).then(
       ([folder, items]) => {
         const images = items.filter(d => (d as any).largeImage);
@@ -164,7 +164,7 @@ export default class GirderAPI {
             return {
               ...asDataset(folder),
               configurations,
-              ...parseTiles(images, tiles, splayXY)
+              ...parseTiles(images, tiles, splayXY, splayZ, splayT)
             };
           }
         );
@@ -564,7 +564,7 @@ function toKey(
   return `z${z}:t${zTime}:xy${xy}:c${c}`;
 }
 
-function parseTiles(items: IGirderItem[], tiles: ITileMeta[], splayXY: boolean) {
+function parseTiles(items: IGirderItem[], tiles: ITileMeta[], splayXY: boolean, splayZ: boolean, splayT: boolean) {
   // t x z x c -> IImage[]
 
   // z -> times
@@ -585,14 +585,14 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[], splayXY: boolean) 
     frameChannels = tile.channels;
 
     tile.frames.forEach((frame, j) => {
-      const t = metadata.t !== null ? metadata.t : frame.IndexT;
+      const t = splayT ? "X" : (metadata.t !== null ? metadata.t : frame.IndexT);
       const xy = splayXY ? "X" : (metadata.xy !== null ? metadata.xy : frame.IndexXY || 0);
-      const z =
-        metadata.z !== null
+      const z = splayZ ? "X" :
+        (metadata.z !== null
           ? metadata.z
           : frame.IndexZ !== undefined
           ? frame.IndexZ
-          : frame.PositionZ;
+          : frame.PositionZ);
       const metadataChannel =
         channelInt.size > 1 ? channelInt.get(metadata.chan) : undefined;
       const c =

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -368,7 +368,7 @@ export default class GirderAPI {
     const hist = this.getResolvedLayerHistogram(images);
     const style = toStyle(color, contrast, hist);
 
-    const rowLength = Math.floor(Math.sqrt(images.length));
+    const rowLength = Math.ceil(Math.sqrt(images.length));
 
     images.forEach((image, idx) => {
       /* This gets each tile separately, but since we get all of them this is
@@ -634,7 +634,7 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
   //
   // TODO: this approach assumes all images have the same size.
   lookup.forEach(images => {
-    const rowLength = Math.floor(Math.sqrt(images.length));
+    const rowLength = Math.ceil(Math.sqrt(images.length));
     const colLength = Math.ceil(images.length / rowLength);
 
     const cwidth = rowLength * images[0].sizeX;

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -152,7 +152,7 @@ export default class GirderAPI {
     );
   }
 
-  getDataset(id: string): Promise<IDataset> {
+  getDataset(id: string, splayXY: boolean): Promise<IDataset> {
     return Promise.all([this.getFolder(id), this.getItems(id)]).then(
       ([folder, items]) => {
         const images = items.filter(d => (d as any).largeImage);
@@ -164,7 +164,7 @@ export default class GirderAPI {
             return {
               ...asDataset(folder),
               configurations,
-              ...parseTiles(images, tiles)
+              ...parseTiles(images, tiles, splayXY)
             };
           }
         );
@@ -564,7 +564,7 @@ function toKey(
   return `z${z}:t${zTime}:xy${xy}:c${c}`;
 }
 
-function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
+function parseTiles(items: IGirderItem[], tiles: ITileMeta[], splayXY: boolean) {
   // t x z x c -> IImage[]
 
   // z -> times
@@ -586,7 +586,7 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[]) {
 
     tile.frames.forEach((frame, j) => {
       const t = metadata.t !== null ? metadata.t : frame.IndexT;
-      const xy = metadata.xy !== null ? metadata.xy : frame.IndexXY || 0;
+      const xy = splayXY ? "X" : (metadata.xy !== null ? metadata.xy : frame.IndexXY || 0);
       const z =
         metadata.z !== null
           ? metadata.z

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -152,7 +152,12 @@ export default class GirderAPI {
     );
   }
 
-  getDataset(id: string, splayXY: boolean, splayZ: boolean, splayT: boolean): Promise<IDataset> {
+  getDataset(
+    id: string,
+    splayXY: boolean,
+    splayZ: boolean,
+    splayT: boolean
+  ): Promise<IDataset> {
     return Promise.all([this.getFolder(id), this.getItems(id)]).then(
       ([folder, items]) => {
         const images = items.filter(d => (d as any).largeImage);
@@ -564,7 +569,13 @@ function toKey(
   return `z${z}:t${zTime}:xy${xy}:c${c}`;
 }
 
-function parseTiles(items: IGirderItem[], tiles: ITileMeta[], splayXY: boolean, splayZ: boolean, splayT: boolean) {
+function parseTiles(
+  items: IGirderItem[],
+  tiles: ITileMeta[],
+  splayXY: boolean,
+  splayZ: boolean,
+  splayT: boolean
+) {
   // t x z x c -> IImage[]
 
   // z -> times
@@ -585,14 +596,19 @@ function parseTiles(items: IGirderItem[], tiles: ITileMeta[], splayXY: boolean, 
     frameChannels = tile.channels;
 
     tile.frames.forEach((frame, j) => {
-      const t = splayT ? "X" : (metadata.t !== null ? metadata.t : frame.IndexT);
-      const xy = splayXY ? "X" : (metadata.xy !== null ? metadata.xy : frame.IndexXY || 0);
-      const z = splayZ ? "X" :
-        (metadata.z !== null
-          ? metadata.z
-          : frame.IndexZ !== undefined
-          ? frame.IndexZ
-          : frame.PositionZ);
+      const t = splayT ? "X" : metadata.t !== null ? metadata.t : frame.IndexT;
+      const xy = splayXY
+        ? "X"
+        : metadata.xy !== null
+        ? metadata.xy
+        : frame.IndexXY || 0;
+      const z = splayZ
+        ? "X"
+        : metadata.z !== null
+        ? metadata.z
+        : frame.IndexZ !== undefined
+        ? frame.IndexZ
+        : frame.PositionZ;
       const metadataChannel =
         channelInt.size > 1 ? channelInt.get(metadata.chan) : undefined;
       const c =

--- a/src/store/images.ts
+++ b/src/store/images.ts
@@ -76,7 +76,7 @@ export function toStyle(
       palette: p
     };
   }
-  if (hist && (contrast.blackPoint !== 0 || contrast.whitePoint !== 100)) {
+  if (hist) {
     const scale = scaleLinear()
       .domain([0, 100])
       .rangeRound([hist.min, hist.max]);
@@ -86,7 +86,8 @@ export function toStyle(
       palette: p
     };
   }
-  // cannot compute absolute values or they are the min/max
+  console.warn('Getting style without histogram information', color, contrast, hist);
+  // cannot compute absolute values
   return {
     min: "min",
     max: "max",

--- a/src/store/images.ts
+++ b/src/store/images.ts
@@ -22,17 +22,17 @@ export function getLayerImages(
     }
   };
 
-  const xyIndex = resolveSlice(layer.xy, xy);
+  const xyIndex = ds.xy.length > 1 ? resolveSlice(layer.xy, xy) : 0;
   // invalid slices
   if (xyIndex < 0 || xyIndex >= ds.xy.length) {
     return [];
   }
-  const zIndex = resolveSlice(layer.z, z);
+  const zIndex = ds.z.length > 1 ? resolveSlice(layer.z, z) : 0;
   // invalid slices
   if (zIndex < 0 || zIndex >= ds.z.length) {
     return [];
   }
-  const tIndex = resolveSlice(layer.time, time);
+  const tIndex = ds.time.length > 1 ? resolveSlice(layer.time, time) : 0;
   if (tIndex < 0 || tIndex >= ds.time.length) {
     return [];
   }

--- a/src/store/images.ts
+++ b/src/store/images.ts
@@ -86,7 +86,6 @@ export function toStyle(
       palette: p
     };
   }
-  console.warn('Getting style without histogram information', color, contrast, hist);
   // cannot compute absolute values
   return {
     min: "min",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -271,7 +271,12 @@ export class Main extends VuexModule {
     }
     try {
       sync.setLoading(true);
-      const r = await this.api.getDataset(id, this.splayXY, this.splayZ, this.splayT);
+      const r = await this.api.getDataset(
+        id,
+        this.splayXY,
+        this.splayZ,
+        this.splayT
+      );
       this.setDataset({ id, data: r });
       sync.setLoading(false);
     } catch (error) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -160,17 +160,17 @@ export class Main extends VuexModule {
   }
 
   @Mutation
-  public setSplayXY(value: boolean) {
+  public setSplayXYImpl(value: boolean) {
     this.splayXY = value;
   }
 
   @Mutation
-  public setSplayZ(value: boolean) {
+  public setSplayZImpl(value: boolean) {
     this.splayZ = value;
   }
 
   @Mutation
-  public setSplayT(value: boolean) {
+  public setSplayTImpl(value: boolean) {
     this.splayT = value;
   }
 
@@ -442,13 +442,28 @@ export class Main extends VuexModule {
   }
 
   @Action
+  async setSplayXY(value: boolean) {
+    this.setSplayXYImpl(value);
+  }
+
+  @Action
   async setZ(value: number) {
     this.setZImpl(value);
   }
 
   @Action
+  async setSplayZ(value: boolean) {
+    this.setSplayZImpl(value);
+  }
+
+  @Action
   async setTime(value: number) {
     this.setTimeImpl(value);
+  }
+
+  @Action
+  async setSplayT(value: boolean) {
+    this.setSplayTImpl(value);
   }
 
   @Mutation

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -54,6 +54,8 @@ export class Main extends VuexModule {
   layerMode: "single" | "multiple" = "multiple";
 
   splayXY: boolean = false;
+  splayZ: boolean = false;
+  splayT: boolean = false;
 
   get userName() {
     return this.girderUser ? this.girderUser.login : "anonymous";
@@ -162,6 +164,16 @@ export class Main extends VuexModule {
     this.splayXY = value;
   }
 
+  @Mutation
+  public setSplayZ(value: boolean) {
+    this.splayZ = value;
+  }
+
+  @Mutation
+  public setSplayT(value: boolean) {
+    this.splayT = value;
+  }
+
   @Action
   async logout() {
     sync.setSaving(true);
@@ -259,7 +271,7 @@ export class Main extends VuexModule {
     }
     try {
       sync.setLoading(true);
-      const r = await this.api.getDataset(id, this.splayXY);
+      const r = await this.api.getDataset(id, this.splayXY, this.splayZ, this.splayT);
       this.setDataset({ id, data: r });
       sync.setLoading(false);
     } catch (error) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -53,6 +53,8 @@ export class Main extends VuexModule {
   compositionMode: CompositionMode = DEFAULT_COMPOSITION_MODE;
   layerMode: "single" | "multiple" = "multiple";
 
+  splayXY: boolean = false;
+
   get userName() {
     return this.girderUser ? this.girderUser.login : "anonymous";
   }
@@ -155,6 +157,11 @@ export class Main extends VuexModule {
     this.time = value;
   }
 
+  @Mutation
+  public setSplayXY(value: boolean) {
+    this.splayXY = value;
+  }
+
   @Action
   async logout() {
     sync.setSaving(true);
@@ -198,6 +205,11 @@ export class Main extends VuexModule {
       // load after logged in
       await this.setSelectedConfiguration(this.selectedConfigurationId);
     }
+  }
+
+  @Action
+  public async refreshDataset() {
+    await this.setSelectedDataset(this.selectedDatasetId);
   }
 
   @Action
@@ -247,7 +259,7 @@ export class Main extends VuexModule {
     }
     try {
       sync.setLoading(true);
-      const r = await this.api.getDataset(id);
+      const r = await this.api.getDataset(id, this.splayXY);
       this.setDataset({ id, data: r });
       sync.setLoading(false);
     } catch (error) {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -35,6 +35,7 @@ export interface IImageTile {
   y: number;
   width: number;
   height: number;
+  frame: number;
   url: string;
   image: HTMLImageElement;
   fullImage: HTMLImageElement;

--- a/src/views/dataset/configuration/Configuration.vue
+++ b/src/views/dataset/configuration/Configuration.vue
@@ -22,7 +22,7 @@ export default routeMapper(
       set: (value: number) => store.setXY(value || 0)
     },
     unrollXY: {
-      parse: v => v === 'true',
+      parse: v => v === "true",
       get: () => store.splayXY,
       set: (value: boolean) => store.setSplayXY(value)
     },
@@ -32,7 +32,7 @@ export default routeMapper(
       set: (value: number) => store.setZ(value || 0)
     },
     unrollZ: {
-      parse: v => v === 'true',
+      parse: v => v === "true",
       get: () => store.splayZ,
       set: (value: boolean) => store.setSplayZ(value)
     },
@@ -42,7 +42,7 @@ export default routeMapper(
       set: (value: number) => store.setTime(value || 0)
     },
     unrollT: {
-      parse: v => v === 'true',
+      parse: v => v === "true",
       get: () => store.splayT,
       set: (value: boolean) => store.setSplayT(value)
     },

--- a/src/views/dataset/configuration/Configuration.vue
+++ b/src/views/dataset/configuration/Configuration.vue
@@ -21,15 +21,30 @@ export default routeMapper(
       get: () => store.xy,
       set: (value: number) => store.setXY(value || 0)
     },
+    unrollXY: {
+      parse: v => v === 'true',
+      get: () => store.splayXY,
+      set: (value: boolean) => store.setSplayXY(value)
+    },
     z: {
       parse: v => parseInt(v, 10),
       get: () => store.z,
       set: (value: number) => store.setZ(value || 0)
     },
+    unrollZ: {
+      parse: v => v === 'true',
+      get: () => store.splayZ,
+      set: (value: boolean) => store.setSplayZ(value)
+    },
     time: {
       parse: v => parseInt(v, 10),
       get: () => store.time,
       set: (value: number) => store.setTime(value || 0)
+    },
+    unrollT: {
+      parse: v => v === 'true',
+      get: () => store.splayT,
+      set: (value: boolean) => store.setSplayT(value)
     },
     mode: {
       parse: v => v as CompositionMode,

--- a/src/views/dataset/configuration/Viewer.vue
+++ b/src/views/dataset/configuration/Viewer.vue
@@ -76,7 +76,8 @@ export default class Viewer extends Vue {
 }
 </style>
 <style>
-.toolbar .v-expansion-panel-content__wrap, .toolbar .v-expansion-panel-header {
+.toolbar .v-expansion-panel-content__wrap,
+.toolbar .v-expansion-panel-header {
   padding-left: 0;
   padding-right: 5px;
 }


### PR DESCRIPTION
This PR adds checkboxes to control whether to unroll the images contained along the XY, Z, and/or T dimensions.

You can use [small3.tar.gz](https://github.com/Kitware/UPennContrast/files/4653464/small3.tar.gz) to test this feature.

~Typechecking is currently failing, though the application does work. Before merging I will fix the typechecking, but I wanted to get a review before doing so (as it may be a bit involved).~ **UPDATE:** typechecking fixed now (2020-05-21 17:54)