### PR TITLE
If the histogram is empty, don't clamp it.

### DIFF
--- a/src/components/ContrastHistogram.vue
+++ b/src/components/ContrastHistogram.vue
@@ -226,6 +226,10 @@ export default class ContrastHistogram extends Vue {
       return;
     }
 
+    if (data.max - data.min <= 1) {
+      return;
+    }
+
     // ensure the values are within the bounds
     const copy = Object.assign({}, this.value);
     const clamp = (value: number) =>

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -250,7 +250,7 @@ export default class ImageViewer extends Vue {
             layerConfig.color,
             layerConfig._histogram.last
           );
-          if (filterURL === '') {
+          if (filterURL === "") {
             return;
           }
           ctx.filter = `url(${filterURL})`;


### PR DESCRIPTION
This resolves #19.