### PR TITLE
Fix scrolling in toolbar.

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -250,7 +250,7 @@ export default class ImageViewer extends Vue {
             layerConfig.color,
             layerConfig._histogram.last
           );
-          if (filterURL === '') {
+          if (filterURL === "") {
             return;
           }
           ctx.filter = `url(${filterURL})`;

--- a/src/components/SwitchToggle.vue
+++ b/src/components/SwitchToggle.vue
@@ -8,8 +8,6 @@
     :false-value="falseValue"
   >
     <template #prepend>
-      <!--styling helper -->
-      <div class="v-input--selection-controls__input" style="width: 0"></div>
       <label
         :class="{
           'v-label': true,

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -1,40 +1,49 @@
 <template>
   <div>
-    <value-slider v-model="xy" label="XY Value" :min="0" :max="maxXY" />
-    <value-slider v-model="z" label="Z Value" :min="0" :max="maxZ" />
-    <value-slider v-model="time" label="Time Value" :min="0" :max="maxTime" />
-    <switch-toggle
-      v-model="layerMode"
-      label="Layers: "
-      true-label="Multiple"
-      true-value="multiple"
-      false-label="Single"
-      false-value="single"
-      id="layerMode"
-    />
-    <slot></slot>
-    <v-select
-      v-model="mode"
-      label="Composition Mode"
-      :items="modes"
-      hide-details
-    >
-      <template #append>
-        <v-btn
-          href="https://mdn.mozillademos.org/en-US/docs/Web/API/Canvas_API/Tutorial/Compositing/Example$samples/Compositing_example"
-          rel="noopener noreferrer"
-          target="_blank"
-          icon
-        >
-          <v-icon>mdi-open-in-new</v-icon>
-        </v-btn>
-      </template>
-    </v-select>
+    <div>
+      <value-slider v-model="xy" label="XY Value" :min="0" :max="maxXY" />
+      <value-slider v-model="z" label="Z Value" :min="0" :max="maxZ" />
+      <value-slider v-model="time" label="Time Value" :min="0" :max="maxTime" />
+      <switch-toggle
+        v-model="layerMode"
+        label="Layers: "
+        true-label="Multiple"
+        true-value="multiple"
+        false-label="Single"
+        false-value="single"
+        id="layerMode"
+      />
+    </div>
+    <div class="lowertools">
+      <slot></slot>
+      <v-select
+        v-model="mode"
+        label="Composition Mode"
+        :items="modes"
+        hide-details
+      >
+        <template #append>
+          <v-btn
+            href="https://mdn.mozillademos.org/en-US/docs/Web/API/Canvas_API/Tutorial/Compositing/Example$samples/Compositing_example"
+            rel="noopener noreferrer"
+            target="_blank"
+            icon
+          >
+            <v-icon>mdi-open-in-new</v-icon>
+          </v-btn>
+        </template>
+      </v-select>
+    </div>
   </div>
 </template>
 <style scoped>
 .v-input--selection-controls {
   margin-top: 0;
+}
+.lowertools {
+  flex: 1;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 </style>
 <script lang="ts">

--- a/src/views/dataset/configuration/Viewer.vue
+++ b/src/views/dataset/configuration/Viewer.vue
@@ -55,13 +55,15 @@ export default class Viewer extends Vue {
 }
 
 .side {
-  display: flex;
-  flex-direction: column;
   width: 20em;
 }
 
 .toolbar {
   padding: 0.5em;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding-bottom: 0;
 }
 
 .layers {
@@ -71,5 +73,11 @@ export default class Viewer extends Vue {
 
 .main {
   flex: 1 1 0;
+}
+</style>
+<style>
+.toolbar .v-expansion-panel-content__wrap, .toolbar .v-expansion-panel-header {
+  padding-left: 0;
+  padding-right: 5px;
 }
 </style>


### PR DESCRIPTION
When the composition control was moved to the bottom (#59), proper scrolling was broken -- scrolling the toolbar needs to not scroll the image area.