### PR TITLE
If unrolling two or more axes, layout in a grid.

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -635,7 +635,12 @@ export class Main extends VuexModule {
       .filter(d => d.visible)
       .map(layer => {
         const images = getLayerImages(layer, ds, this.time, this.xy, this.z);
-        return this.api.generateImages(images, layer.color, layer.contrast);
+        return this.api.generateImages(
+          images,
+          layer.color,
+          layer.contrast,
+          ds.width
+        );
       });
   }
 


### PR DESCRIPTION
If you unroll two or more axes, the first axis is unrolled horizontally and the rest vertically.

This may not be ideal, especially if you unroll three axes.  For three axes, it might be better to determine which of axes 1&2 x axis 3 and axis 1 x axes 2&3 are squarer.

Further, the axes are unrolled in the order they are reported by the file, which isn't guaranteed to be the order of the axes in the UI.  For instance, in normmedia_8well_col2_livecellgfp.nd2, there are 6 XY, 7 Z, and 4 T values.  Since T is reported first, it unrolls T horizontally and XY or Z vertically, but we list time third in the UI.