### PR TITLE
Fix waiting spinner.

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -359,7 +359,7 @@ export default class ImageViewer extends Vue {
             }
           });
         }
-        const idle = fullLayer.idle && adjLayer.idle;
+        const idle = /* fullLayer.idle && */ adjLayer.idle;
         fullLayer
           .node()
           .css("visibility", !idle && layer.visible ? "visible" : "hidden");


### PR DESCRIPTION
If the fully adjusted layer finished rendering before the preview layer, the spinner could remain spinning even though it was done.