### PR TITLE
For large images, use a reduced image for histograms.

### DIFF
--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -258,9 +258,7 @@ export default class GirderAPI {
       images,
       (image: IImage) =>
         this.getHistogram(image.item, {
-          frame: image.frameIndex,
-          width: image.sizeX,
-          height: image.sizeY
+          frame: image.frameIndex
         }),
       { concurrency: HistogramConcurrency }
     ).then((histograms: ITileHistogram[]) => mergeHistograms(histograms));


### PR DESCRIPTION
This was using every pixel to compute histograms, which is very slow on large images.  Instead, use a maximum image size of 2048 x 2048.