### PR TITLE
Handle recent changes to the nd2reader.

### DIFF
--- a/devops/girder/Dockerfile
+++ b/devops/girder/Dockerfile
@@ -1,8 +1,12 @@
 FROM girder/girder:latest-py3
 
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends fuse
+RUN mkdir /mnt/fuse
+
 WORKDIR /src
 RUN git clone https://github.com/girder/large_image.git
 WORKDIR /src/large_image
-RUN pip install -e . -rrequirements-dev.txt --find-links https://girder.github.io/large_image_wheels
+RUN pip install -e . -rrequirements-dev.txt girder[mount] --find-links https://girder.github.io/large_image_wheels
 
 RUN girder build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,9 @@ services:
   girder:
     build:
       context: ./devops/girder
-    command: "-d mongodb://mongodb:27017/girder --host 0.0.0.0"
+    privileged: true
+    entrypoint: bash
+    command: -c "girder mount /mnt/fuse -d mongodb://mongodb:27017/girder && girder serve -d mongodb://mongodb:27017/girder --host 0.0.0.0"
     ports:
       - "${GIRDER_PORT-8080}:8080"
     links:


### PR DESCRIPTION
The latest version of n2reader requires that file extensions match expected values.  For the general case, we support this through girder mount, which requires installing fuse and running docker with elevated privileges.