### PR TITLE
Fix an issue if the first layer had no images.

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -189,8 +189,12 @@ export default class ImageViewer extends Vue {
     if (!this.layerStackImages.length) {
       return;
     }
-    let unrollCount = this.layerStackImages[0].images.length;
-    const someImage = this.layerStackImages[0].images[0];
+    const someImages = this.layerStackImages.find((lsi: any) => lsi.images[0]);
+    if (!someImages) {
+      return;
+    }
+    let unrollCount = someImages.images.length;
+    const someImage = someImages.images[0];
     let unrollW = Math.min(
       unrollCount,
       Math.ceil(


### PR DESCRIPTION
If the first layer is set to an offset such that there is no image available (e.g., at z = 0 with an offset of -1), the drawing function would through an exception.  Now, first the first layer with an available image.