### PR TITLE
Use background quads for smoother transitions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8030,9 +8030,9 @@
       "dev": true
     },
     "geojs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/geojs/-/geojs-1.2.0.tgz",
-      "integrity": "sha512-5IlyUZH1IKJ4++W5qwIZPWcQC1lrMCssEq0vhTE3lQ8w1G7auKJ0ZRkn3GZZUagy8apHeStvPgX9+/R+L9YZ0A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/geojs/-/geojs-1.4.0.tgz",
+      "integrity": "sha512-PFR5nsBBcMqss703iG0D455m46wug8VZRTvngBN1d/em3tsm6+KYhPpXzbDl4TnorFzjYGEf94D/rdXwBoIn1g==",
       "dev": true,
       "requires": {
         "color-name": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint": "^6.7.2",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-vue": "^6.0.1",
-    "geojs": "^1.2.0",
+    "geojs": "^1.4.0",
     "node-sass": "^4.13.0",
     "prettier": "^1.19.1",
     "pug": "^3.0.1",

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -17,7 +17,7 @@
         style="width: 200px"
       />
     </div>
-    <svg xmlns="http://www.w3.org/2000/svg">
+    <svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" style="position: absolute; top: -1px; left: -1px">
       <defs>
         <filter
           :id="'recolor-' + index"
@@ -398,8 +398,10 @@ export default class ImageViewer extends Vue {
       };
     }
     this.ready.layers.splice(this.layerStackImages.length);
-    this.annotationLayer.moveToTop();
-    this.uiLayer.moveToTop();
+    if (this.annotationLayer.zIndex() !== this.layerStackImages.length * 2 || this.uiLayer.zIndex() !== this.layerStackImages.length * 2 + 1) {
+      this.annotationLayer.moveToTop();
+      this.uiLayer.moveToTop();
+    }
     // set tile urls
     this.layerStackImages.forEach(
       (

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -83,8 +83,14 @@ function generateFilterURL(
     const wpP = wp;
     const bpP = bp;
 
-    el.setAttribute("slope", `${levelP / (wpP - bpP)}`);
-    el.setAttribute("intercept", `${-(levelP * bpP) / (wpP - bpP)}`);
+    const slope = `${levelP / (wpP - bpP)}`;
+    const intercept = `${-(levelP * bpP) / (wpP - bpP)}`;
+    if (slope != el.getAttribute("slope")) {
+      el.setAttribute("slope", slope);
+    }
+    if (intercept != el.getAttribute("intercept")) {
+      el.setAttribute("intercept", intercept);
+    }
   };
 
   const scalePoint = (val: number, mode: string) =>
@@ -429,6 +435,7 @@ export default class ImageViewer extends Vue {
             fullLayer.visible(false);
           }
           adjLayer.visible(false);
+          adjLayer.node().css("visibility", "hidden");
           Vue.set(this.ready.layers, layerIndex, true);
           return;
         }

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -524,6 +524,7 @@ function parseTiles(
         sizeY: tile.sizeY,
         tileWidth: tile.tileWidth,
         tileHeight: tile.tileHeight,
+        tileinfo: tile,
         mm_x: tile.mm_x,
         mm_y: tile.mm_y
       };

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -37,6 +37,7 @@ export interface IImage {
   tileHeight: number;
   mm_x: number;
   mm_y: number;
+  tileinfo: any;
 }
 
 export interface IImageTile {

--- a/src/utils/README.txt
+++ b/src/utils/README.txt
@@ -1,0 +1,6 @@
+The setQuadFrame.js file is copied from large_image; it should be changed toi
+pull from npm once it is published there -- for now, in large_image it is 
+bundled with the Girder plugin, but since we aren't using that directly, it 
+isn't usable from there.
+
+

--- a/src/utils/setFrameQuad.d.ts
+++ b/src/utils/setFrameQuad.d.ts
@@ -1,0 +1,5 @@
+export default function setFrameQuad(
+  tileinfo: any,
+  layer: any,
+  options: any
+): any;

--- a/src/utils/setFrameQuad.js
+++ b/src/utils/setFrameQuad.js
@@ -1,0 +1,251 @@
+/**
+ * Given metadata on a tile source, a GeoJS tileLayer,  and a set of options,
+ * add a function to the layer `setFrameQuad(<frame>)` that will, if possible,
+ * set the baseQuad to a cropped section of an image that contains excerpts of
+ * all frames.
+ *
+ * @param {object} tileinfo The metadata of the source image.  This expects
+ *   ``sizeX`` and ``sizeY`` to be the width and height of the image and
+ *   ``frames`` to contain a list of the frames of the image or be undefined if
+ *   there is only one frame.
+ * @param {geo.tileLayer} layer The GeoJS layer to add the function to.  This
+ *   is also used to get a maximal texture size if the layer is a webGL
+ *   layer.
+ * @param {object} options Additional options for the function.  This must
+ *   minimally include ``baseUrl``.
+ * @param {string} options.baseUrl The reference to the tile endpoint, e.g.,
+ *   <url>/api/v1/item/<item id>/tiles.
+ * @param {string} [options.format='encoding=JPEG&jpegQuality=85&jpegSubsampling=1']
+ *   The compression and format for the texture.
+ * @param {string} [options.query] Additional query options to add to the
+ *   tile_frames endpoint, e.g. 'style={"min":"min","max":"max"}'.  Do not
+ *   include framesAcross or frameList.  You must specify 'cache=true' if
+ *   that is desired.
+ * @param {number} [options.frameBase=0] Starting frame number used.
+ * @param {number} [options.frameStride=1] Only use ever ``frameStride`` frame
+ *   of the image.
+ * @param {number} [options.maxTextureSize] Limit the maximum texture size to a
+ *   square of this size.  The size is also limited by the WebGL maximum
+ *   size for webgl-based layers or 16384 for canvas-based layers.
+ * @param {number} [options.maxTextures=1] If more than one, allow multiple
+ *   textures to increase the size of the individual frames.  The number of
+ *   textures will be capped by ``maxTotalTexturePixels`` as well as this
+ *   number.
+ * @param {number} [options.maxTotalTexturePixels=1073741824] Limit the
+ *   maximum texture size and maximum number of textures so that the combined
+ *   set does not exceed this number of pixels.
+ * @param {number} [options.alignment=16] Individual frames are buffer to an
+ *   alignment of this maxy pixels.  If JPEG compression is used, this should
+ *   be 8 for monochrome images or jpegs without subsampling, or 16 for jpegs
+ *   with moderate subsampling to avoid compression artifacts from leaking
+ *   between frames.
+ * @param {number} [options.adjustMinLevel=true] If truthy, adjust the tile
+ *   layer's minLevel after the quads are loaded.
+ * @param {number} [options.maxFrameSize] If set, limit the maximum width and
+ *   height of an individual frame to this value.
+ * @param {string} [options.crossOrigin] If specified, use this as the
+ *   crossOrigin policy for images.
+ */
+function setFrameQuad(tileinfo, layer, options) {
+  layer.setFrameQuad = function() {};
+  if (
+    !tileinfo ||
+    !tileinfo.sizeX ||
+    !tileinfo.sizeY ||
+    !options ||
+    !options.baseUrl
+  ) {
+    return;
+  }
+  let maxTextureSize;
+  try {
+    maxTextureSize =
+      layer.renderer()._maxTextureSize ||
+      layer.renderer().constructor._maxTextureSize;
+  } catch (err) {}
+  const w = tileinfo.sizeX,
+    h = tileinfo.sizeY,
+    maxTotalPixels = options.maxTotalTexturePixels || 1073741824,
+    alignment = options.alignment || 16;
+  let numFrames = (tileinfo.frames || []).length || 1,
+    texSize = maxTextureSize || 16384,
+    textures = options.maxTextures || 1;
+  const frames = [];
+  for (
+    let fidx = options.frameBase || 0;
+    fidx < numFrames;
+    fidx += options.frameStride || 1
+  ) {
+    frames.push(fidx);
+  }
+  numFrames = frames.length;
+  if (numFrames === 0 || !Object.getOwnPropertyDescriptor(layer, "baseQuad")) {
+    return;
+  }
+  texSize = Math.min(texSize, options.maxTextureSize || texSize);
+  while (texSize ** 2 > maxTotalPixels) {
+    texSize /= 2;
+  }
+  while (textures && texSize ** 2 * textures > maxTotalPixels) {
+    textures -= 1;
+  }
+  let fw, fh, fhorz, fvert;
+  /* Iterate in case we can reduce the number of textures or the texture
+   * size */
+  while (true) {
+    const f = Math.ceil(numFrames / textures); // frames per texture
+    const texScale2 = texSize ** 2 / f / w / h;
+    // frames across the texture
+    fhorz = Math.ceil(
+      texSize / (Math.floor((w * texScale2 ** 0.5) / alignment) * alignment)
+    );
+    fvert = Math.ceil(
+      texSize / (Math.floor((h * texScale2 ** 0.5) / alignment) * alignment)
+    );
+    // tile sizes
+    fw = Math.floor(texSize / fhorz / alignment) * alignment;
+    fh = Math.floor(texSize / fvert / alignment) * alignment;
+    if (options.maxFrameSize) {
+      const maxFrameSize =
+        Math.floor(options.maxFrameSize / alignment) * alignment;
+      fw = Math.min(fw, maxFrameSize);
+      fh = Math.min(fh, maxFrameSize);
+    }
+    if (fw > w) {
+      fw = Math.ceil(w / alignment) * alignment;
+    }
+    if (fh > h) {
+      fh = Math.ceil(h / alignment) * alignment;
+    }
+    // shrink one dimension so account for aspect ratio
+    fw = Math.min(Math.ceil((fw * w) / h / alignment) * alignment, fw);
+    fh = Math.min(Math.ceil((fw * h) / w / alignment) * alignment, fh);
+    // recompute frames across the texture
+    fhorz = Math.floor(texSize / fw);
+    fvert = Math.min(Math.floor(texSize / fh), Math.ceil(numFrames / fhorz));
+    // check if we are not using all textires or are using less than a
+    // quarter of one texture.  If not, stop, if so, reduce and recalculate
+    if (textures > 1 && numFrames <= fhorz * fvert * (textures - 1)) {
+      textures -= 1;
+      continue;
+    }
+    if (
+      fhorz >= 2 &&
+      Math.ceil(f / Math.floor(fhorz / 2)) * fh <= texSize / 2
+    ) {
+      texSize /= 2;
+      continue;
+    }
+    break;
+  }
+  // used area of each tile
+  const usedw = Math.floor(w / Math.max(w / fw, h / fh)),
+    usedh = Math.floor(h / Math.max(w / fw, h / fh));
+  // get the set of texture images
+  const status = {
+    tileinfo: tileinfo,
+    options: options,
+    images: [],
+    src: [],
+    quads: [],
+    frames: frames,
+    framesToIdx: {}
+  };
+  if (tileinfo.tileWidth && tileinfo.tileHeight) {
+    // report that tiles below this level are not needed
+    status.minLevel = Math.ceil(
+      Math.log(
+        Math.min(usedw / tileinfo.tileWidth, usedh / tileinfo.tileHeight)
+      ) / Math.log(2)
+    );
+  }
+  frames.forEach((frame, idx) => {
+    status.framesToIdx[frame] = idx;
+  });
+  for (let idx = 0; idx < textures; idx += 1) {
+    const img = new Image();
+    if (
+      options.baseUrl.indexOf(":") >= 0 &&
+      options.baseUrl.indexOf("/") === options.baseUrl.indexOf(":") + 1
+    ) {
+      img.crossOrigin = options.crossOrigin || "anonymous";
+    }
+    const frameList = frames.slice(
+      idx * fhorz * fvert,
+      (idx + 1) * fhorz * fvert
+    );
+    let src = `${options.baseUrl}/tile_frames?framesAcross=${fhorz}&width=${fw}&height=${fh}&fill=corner:black&exact=false`;
+    if (frameList.length !== (tileinfo.frames || []).length) {
+      src += `&frameList=${frameList.join(",")}`;
+    }
+    src +=
+      "&" +
+      (
+        options.format || "encoding=JPEG&jpegQuality=85&jpegSubsampling=1"
+      ).replace(/(^&|^\?|\?$|&$)/g, "");
+    if (options.query) {
+      src += "&" + options.query.replace(/(^&|^\?|\?$|&$)/g, "");
+    }
+    status.src.push(src);
+    if (idx === textures - 1) {
+      img.onload = function() {
+        status.loaded = true;
+        if (
+          layer._options &&
+          layer._options.minLevel !== undefined &&
+          (options.adjustMinLevel === undefined || options.adjustMinLevel) &&
+          status.minLevel &&
+          status.minLevel > layer._options.minLevel
+        ) {
+          layer._options.minLevel = Math.min(
+            layer._options.maxLevel,
+            status.minLevel
+          );
+        }
+      };
+    } else {
+      (idx => {
+        img.onload = function() {
+          status.images[idx + 1].src = status.src[idx + 1];
+        };
+      })(idx);
+    }
+    status.images.push(img);
+    // the last image can have fewer frames than the other images
+    const f = frameList.length;
+    const ivert = Math.ceil(f / fhorz),
+      ihorz = Math.min(f, fhorz);
+    frameList.forEach((frame, fidx) => {
+      const quad = {
+        // z = -1 to place under other tile layers
+        ul: { x: 0, y: 0, z: -1 },
+        // y coordinate is inverted
+        lr: { x: w, y: -h, z: -1 },
+        crop: {
+          x: w,
+          y: h,
+          left: (fidx % ihorz) * fw,
+          top: (ivert - Math.floor(fidx / ihorz)) * fh - usedh,
+          right: (fidx % ihorz) * fw + usedw,
+          bottom: (ivert - Math.floor(fidx / ihorz)) * fh
+        },
+        image: img
+      };
+      status.quads.push(quad);
+    });
+  }
+  status.images[0].src = status.src[0];
+
+  layer.setFrameQuad = function(frame) {
+    if (status.framesToIdx[frame] !== undefined) {
+      layer.baseQuad = Object.assign(
+        {},
+        status.quads[status.framesToIdx[frame]]
+      );
+      status.frame = frame;
+    }
+  };
+  layer.setFrameQuad.status = status;
+}
+
+export default setFrameQuad;


### PR DESCRIPTION
This has some tunable parameters to fetch more background quad images or use more or less texture memory.  Using more background textures results in some texture memory loading spikes that manifest as some initial hesitation in z scrolling, but produce nicer images.