### PR TITLE
Change tile frames defaults.

### DIFF
--- a/devops/girder/provision.py
+++ b/devops/girder/provision.py
@@ -21,6 +21,10 @@ def provision(opts):
         # on subsequent starts.
         Setting().set('core.cors.allow_origin', '*')
 
+        # Increase the allowed files that can be cached, as this is used for
+        # tiled frames
+        Setting().set('large_image.max_thumbnail_files', 400)
+
     # Make sure we have an assetstore
     if Assetstore().findOne() is None:
         Assetstore().createFilesystemAssetstore('Assetstore', '/assetstore')

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -495,7 +495,10 @@ export default class ImageViewer extends Vue {
       }
     );
     this.map.draw();
+    /* Disable running cacneWhenIdle; it doesn't help much now that we have
+     * tile frame previews
     this.map.onIdle(this.cacheWhenIdle);
+     */
   }
 
   beforeDestroy() {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -733,7 +733,8 @@ export class Main extends VuexModule {
       if (results.fullUrls && results.fullUrls.length && results.fullUrls[0]) {
         results.baseQuadOptions = {
           baseUrl: results.fullUrls[0].split("/tiles")[0] + "/tiles",
-          // maxTextures: 8,
+          maxTextures: 32,
+          maxTextureSize: 4096,
           query:
             "style=" +
             encodeURIComponent(

--- a/src/utils/setFrameQuad.js
+++ b/src/utils/setFrameQuad.js
@@ -26,7 +26,7 @@
  *   of the image.
  * @param {number} [options.maxTextureSize] Limit the maximum texture size to a
  *   square of this size.  The size is also limited by the WebGL maximum
- *   size for webgl-based layers or 16384 for canvas-based layers.
+ *   size for webgl-based layers or 8192 for canvas-based layers.
  * @param {number} [options.maxTextures=1] If more than one, allow multiple
  *   textures to increase the size of the individual frames.  The number of
  *   textures will be capped by ``maxTotalTexturePixels`` as well as this
@@ -68,7 +68,7 @@ function setFrameQuad(tileinfo, layer, options) {
     maxTotalPixels = options.maxTotalTexturePixels || 1073741824,
     alignment = options.alignment || 16;
   let numFrames = (tileinfo.frames || []).length || 1,
-    texSize = maxTextureSize || 16384,
+    texSize = maxTextureSize || 8192,
     textures = options.maxTextures || 1;
   const frames = [];
   for (
@@ -97,10 +97,10 @@ function setFrameQuad(tileinfo, layer, options) {
     const texScale2 = texSize ** 2 / f / w / h;
     // frames across the texture
     fhorz = Math.ceil(
-      texSize / (Math.floor((w * texScale2 ** 0.5) / alignment) * alignment)
+      texSize / (Math.ceil((w * texScale2 ** 0.5) / alignment) * alignment)
     );
     fvert = Math.ceil(
-      texSize / (Math.floor((h * texScale2 ** 0.5) / alignment) * alignment)
+      texSize / (Math.ceil((h * texScale2 ** 0.5) / alignment) * alignment)
     );
     // tile sizes
     fw = Math.floor(texSize / fhorz / alignment) * alignment;


### PR DESCRIPTION
This uses smaller but more textures.

This also adjusts a cache setting on the server to allow caching more tile frame textures.