### PR TITLE
Don't expose mongo's port.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,6 @@ services:
     image: mongo
     volumes:
       - "./db:/data/db"
-    ports:
-      - "27017:27017"
 
   girder:
     build:


### PR DESCRIPTION
The girder container can access it as is, so there is no need.