### PR TITLE
Guard index values.

### DIFF
--- a/devops/girder/annotation_client/annotation_client/tiles.py
+++ b/devops/girder/annotation_client/annotation_client/tiles.py
@@ -44,10 +44,10 @@ class UPennContrastDataset:
 
         map = {}
         for frame in frames:
-            channel = frame['IndexC']
-            XY = frame['IndexXY']
-            Z = frame['IndexZ']
-            T = frame['IndexT']
+            channel = frame.get('IndexC', 0)
+            XY = frame.get('IndexXY', 0)
+            Z = frame.get('IndexZ', 0)
+            T = frame.get('IndexT', 0)
             index = frame['Frame']
 
             map.setdefault(channel, {}).setdefault(


### PR DESCRIPTION
They aren't all guaranteed to exist, depending on the tile source and format.

Fixes #210.