### PR TITLE
Increase the tile queue tracking parameter.

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -310,6 +310,12 @@ export default class ImageViewer extends Vue {
       }
       if (this.imageLayers.length) {
         this.layerParams.queue = this.imageLayers[0].queue;
+        // note: we should refactor this if we expose the _track parameter
+        // officially.
+        this.imageLayers[0].queue._track = Math.max(
+          this.imageLayers[0].queue._track,
+          (this.imageLayers.length + 1) * 600
+        );
       }
       this.imageLayers.push(this.map.createLayer("osm", this.layerParams));
       let layer = this.imageLayers[this.imageLayers.length - 1];


### PR DESCRIPTION
The default is large enough for a single layer, but we have lots of layers.  Making it bigger uses more browser memory but prevents trying to discard tiles needlessly.  Ideally, we'd modify geojs so when layers share a tile queue the tracking parameter would be a per-lyater value not a fixed value.

There is even a note in geojs saying if the track value is too low, it will cause needless computation.

I may automate this in geojs instead of the merging this PR.