### PR TITLE
Improve the test environment.

### DIFF
--- a/devops/girder/Dockerfile
+++ b/devops/girder/Dockerfile
@@ -1,7 +1,12 @@
 FROM girder/girder:latest-py3
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends fuse
+    apt-get install --yes --no-install-recommends \
+    fuse \
+    iptables \
+    dnsutils \
+    && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN mkdir /mnt/fuse
 
 WORKDIR /src
@@ -16,5 +21,8 @@ RUN pip install -e /src/AnnotationPlugin
 
 COPY ./provision.py /src/provision.py
 COPY ./girder.cfg /etc/girder.cfg
+COPY ./test_env.sh /src/test_env.sh
+
+WORKDIR /src/AnnotationPlugin
 
 ENTRYPOINT ["bash"]

--- a/devops/girder/plugins/AnnotationPlugin/setup.py
+++ b/devops/girder/plugins/AnnotationPlugin/setup.py
@@ -20,7 +20,9 @@ setup(name='upenncontrast_annotation',
       ],
       install_requires=[
           'girder_worker',
-          'girder_worker_utils'
+          'girder_worker_utils',
+          'girder-large-image',
+          'large-image[sources]',
       ],
       extras_require={
           'girder': [

--- a/devops/girder/plugins/AnnotationPlugin/tox.ini
+++ b/devops/girder/plugins/AnnotationPlugin/tox.ini
@@ -6,6 +6,8 @@ skip_missing_interpreters = true
 
 [testenv]
 passenv = PYTEST_*
+setenv =
+  PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
 deps =
   -rrequirements-dev.txt
   mock

--- a/devops/girder/test_env.sh
+++ b/devops/girder/test_env.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Allow testing to treat the mongo container as if on localhost
+sysctl -w net.ipv4.conf.eth0.route_localnet=1
+iptables -t nat -A OUTPUT -o lo -p tcp -m tcp --dport 27017 -j DNAT --to-destination `dig +short mongodb`:27017
+iptables -t nat -A POSTROUTING -o eth0 -m addrtype --src-type LOCAL --dst-type UNICAST -j MASQUERADE


### PR DESCRIPTION
Specifically, the Girder plugin setup.py file was missing some requirements.  The tox file should specify using find-links to fetch large_image wheels.  The Dockerfile now more conveniently starts in the directory where the plugin is located.  Lastly, there is a test_env.sh script that can be run in the docker to allow girder tests to properly find mongo (unfortunately, girder tests expect mongo to be on localhost, which isn't the case in a docker-compose environment).