### PR TITLE
Bug fix: right panel overlap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 node_modules
 /dist
+/assetstore
+/db
 multi_data
 # local env files
 *.local

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,11 +7,11 @@
       >
       <bread-crumbs />
       <v-spacer />
-      <v-btn @click.stop="snapshotPanel = !snapshotPanel" id="snapshotButton"
+      <v-btn @click.stop="updateRightPanel('snapshotPanel')" id="snapshotButton"
         >Snapshot</v-btn
       >
       <user-menu />
-      <v-btn @click.stop="annotationPanel = !annotationPanel"
+      <v-btn @click.stop="updateRightPanel('annotationPanel')"
         >Browse Annotations</v-btn
       >
       <server-status />
@@ -83,6 +83,8 @@ export default class App extends Vue {
 
   annotationPanel = false;
 
+  lastRightPanelUpdate: string | undefined;
+
   fetchConfig() {
     // Fetch the list of available tool templates
     // It consists of a json file containing a list of items, each item describing
@@ -108,6 +110,18 @@ export default class App extends Vue {
 
   goHome() {
     this.$router.push({ name: "root" });
+  }
+
+  updateRightPanel(panel: string) {
+    this.$data[panel] = !this.$data[panel];
+    // The last panel updated has to be closed if it is not the currently updated panel
+    if (
+      this.lastRightPanelUpdate !== undefined &&
+      this.lastRightPanelUpdate !== panel
+    ) {
+      this.$data[this.lastRightPanelUpdate] = false;
+    }
+    this.lastRightPanelUpdate = panel;
   }
 }
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,11 +7,11 @@
       >
       <bread-crumbs />
       <v-spacer />
-      <v-btn @click.stop="updateRightPanel('snapshotPanel')" id="snapshotButton"
+      <v-btn @click.stop="toggleRightPanel('snapshotPanel')" id="snapshotButton"
         >Snapshot</v-btn
       >
       <user-menu />
-      <v-btn @click.stop="updateRightPanel('annotationPanel')"
+      <v-btn @click.stop="toggleRightPanel('annotationPanel')"
         >Browse Annotations</v-btn
       >
       <server-status />
@@ -83,7 +83,7 @@ export default class App extends Vue {
 
   annotationPanel = false;
 
-  lastRightPanelUpdate: string | undefined;
+  lastModifiedRightPanel: string | null = null;
 
   fetchConfig() {
     // Fetch the list of available tool templates
@@ -112,16 +112,16 @@ export default class App extends Vue {
     this.$router.push({ name: "root" });
   }
 
-  updateRightPanel(panel: string) {
+  toggleRightPanel(panel: string) {
     this.$data[panel] = !this.$data[panel];
     // The last panel updated has to be closed if it is not the currently updated panel
     if (
-      this.lastRightPanelUpdate !== undefined &&
-      this.lastRightPanelUpdate !== panel
+      this.lastModifiedRightPanel !== null &&
+      this.lastModifiedRightPanel !== panel
     ) {
-      this.$data[this.lastRightPanelUpdate] = false;
+      this.$data[this.lastModifiedRightPanel] = false;
     }
-    this.lastRightPanelUpdate = panel;
+    this.lastModifiedRightPanel = panel;
   }
 }
 </script>


### PR DESCRIPTION
Bug found: opening both right panels together ("Snapshot" and "Browse annotations") creates a UI bug
Fixed it by allowing only a single right panel to be open at a time
Also added `/assetstore` and `/db` to `.gitignore`