### PR TITLE
Improve connections

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
@@ -19,6 +19,7 @@ class AnnotationConnection(Resource):
         self.route('GET', (), self.find)
         self.route('POST', (), self.create)
         self.route('PUT', (':id',), self.update)
+        self.route('POST',('connectTo',) , self.connectToNearest)
 
     # TODO: anytime a dataset is mentioned, load the dataset and check for existence and that the user has access to it
     # TODO: load both childe and parent annotations, and check that they share existence, access and location
@@ -89,3 +90,12 @@ class AnnotationConnection(Resource):
     @loadmodel(model='annotation_connection', plugin='upenncontrast_annotation', level=AccessType.READ)
     def get(self, annotation_connection):
         return annotation_connection
+
+
+    @access.user
+    @describeRoute(Description("Create connections between annotations").param('body', 'Connection Object', paramType='body'))
+    def connectToNearest(self, params):
+        currentUser = self.getCurrentUser()
+        if not currentUser:
+            raise AccessException('User not found', 'currentUser')
+        return self._connectionModel.connectToNearest(user=currentUser, info=self.getBodyJson())

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/connections.py
@@ -1,0 +1,76 @@
+import math
+import numpy as np
+
+def pointToPointDistance(coord1, coord2):
+    """Get the distance between two points using points coordinates.
+    Points coordinates are represented by {x: x_coord, y: y_coord, z: z_coord}.
+
+    Args:
+        coord1 (dict): Coordinates of point 1
+        coord2 (dict): Coordinates of point 2
+
+    Returns:
+        Number: Squared distance between point1 and point2
+    """
+    return math.sqrt(
+      math.pow(coord1["x"] - coord2["x"], 2) + math.pow(coord1["y"] - coord2["y"], 2) + math.pow(coord1["z"] - coord2["z"], 2)
+    )
+  
+
+def simpleCentroid(listCoordinates):
+    """Compute the simple centroid of a polygon using its list of coordinates.
+    The centroid corresponds to the barycenter of the polygon.
+
+    Args:
+        listCoordinates (dict[]): List of point coordinates.
+          Point coordinates are represented by {x: x_coord, y: y_coord, z: z_coord}
+
+    Returns:
+        dict: Coordinates of the centroid
+    """
+    nbCoordinates = len(listCoordinates)
+    x = np.sum([coord["x"] for coord in listCoordinates]) / nbCoordinates
+    y = np.sum([coord["y"] for coord in listCoordinates]) / nbCoordinates
+    z = np.sum([coord["z"] for coord in listCoordinates]) / nbCoordinates
+
+    return {
+      "x": x,
+      "y": y,
+      "z": z
+    }
+
+def isAPoint(annotation):
+  return annotation["shape"] == 'point'
+
+def isAPoly(annotation):
+  return (annotation["shape"] == 'polygon' or annotation["shape"] == 'line')
+
+def annotationToAnnotationDistance(annotation1, annotation2):
+    """Compute the distance between two annotations
+
+    Args:
+        annotation1 (_type_): _description_
+        annotation2 (_type_): _description_
+
+    Returns:
+        Number: Distance between the two annotations
+    """
+    # Point to point
+    if isAPoint(annotation1) and isAPoint(annotation2):
+      return  pointToPointDistance(annotation1["coordinates"][0], annotation2["coordinates"][0])
+    
+    # Compute centroid distance
+    if (isAPoint(annotation1) and isAPoly(annotation2)) or (isAPoly(annotation1) and isAPoint(annotation2)):
+      point = annotation1 if isAPoint(annotation1) else annotation2
+      poly = annotation1 if isAPoly(annotation1) else annotation2
+      centroid = simpleCentroid(poly["coordinates"])
+
+      return pointToPointDistance(point["coordinates"][0], centroid)
+
+    # Poly to poly
+    if isAPoly(annotation1) and isAPoly(annotation2):
+      centroid1 = simpleCentroid(annotation1["coordinates"])
+      centroid2 = simpleCentroid(annotation2["coordinates"])
+      return pointToPointDistance(centroid1, centroid2)
+    
+    return math.inf

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_connections.py
@@ -1,18 +1,24 @@
+from cgi import test
 from jsonschema.validators import create
 import pytest
-
-import random
-import copy
+import math
 
 from upenncontrast_annotation.server.models.annotation import Annotation
 from upenncontrast_annotation.server.models.connections import AnnotationConnection
 from upenncontrast_annotation.server.models import connections
+from upenncontrast_annotation.server.helpers.connections import (
+    annotationToAnnotationDistance,
+    isAPoint,
+    isAPoly,
+    simpleCentroid,
+    pointToPointDistance
+)
 
 from . import girder_utilities as utilities
 from . import upenn_testing_utilities as upenn_utilities
 
 from girder.constants import AccessType
-from girder.exceptions import AccessException, ValidationException
+from girder.exceptions import ValidationException
 from girder.models.folder import Folder
 
 
@@ -157,3 +163,282 @@ class TestConnection:
             parent['_id'], child['_id'], folder['_id'])
         with pytest.raises(ValidationException, match='not a dataset'):
             AnnotationConnection().validate(connection)
+
+
+@pytest.mark.plugin('upenncontrast_annotation')
+class TestConnectToNearest:
+    pointAnnotationRef = {
+        "_id": "0",
+        "channel": 0,
+        "coordinates": [{
+            "x": 11,
+            "y": 8,
+            "z": 0
+        }],
+        "datasetId": "111",
+        "location": {
+            "Time": 0,
+            "XY": 0,
+            "Z": 0
+        },
+        "shape": "point",
+        "tags": [
+            "reference"
+        ]
+    }
+    pointAnnotations = [
+        {
+            "_id": "1",
+            "channel": 0,
+            "coordinates": [
+            {
+                "x": 6,
+                "y": 7,
+                "z": 0
+            }
+            ],
+            "datasetId": "111",
+            "location": {
+                "Time": 0,
+                "XY": 0,
+                "Z": 0
+            },
+            "shape": "point",
+            "tags": [
+                "other"
+            ]
+        },
+        {
+            "_id": "2",
+            "channel": 0,
+            "coordinates": [
+            {
+                "x": 14,
+                "y": 5,
+                "z": 0
+            }
+            ],
+            "datasetId": "111",
+            "location": {
+                "Time": 0,
+                "XY": 0,
+                "Z": 0
+            },
+            "shape": "point",
+            "tags": [
+                "others"
+            ]
+        }
+    ]
+    lineAnnotations = [
+        {
+            "_id": "3",
+            "channel": 0,
+            "coordinates": [
+                {
+                    "x": 2,
+                    "y": 6,
+                    "z": 0
+                },
+                {
+                    "x": 6,
+                    "y": 11,
+                    "z": 0
+                }
+            ],
+            "datasetId": "111",
+            "location": {
+                "Time": 0,
+                "XY": 0,
+                "Z": 0
+            },
+            "shape": "line",
+            "tags": [
+                "other"
+            ]
+        },
+        {
+            "_id": "4",
+            "channel": 0,
+            "coordinates": [
+                {
+                    "x": 20,
+                    "y": 2,
+                    "z": 0
+                },
+                {
+                    "x": 21,
+                    "y": 9,
+                    "z": 0
+                }
+            ],
+            "datasetId": "111",
+            "location": {
+                "Time": 0,
+                "XY": 0,
+                "Z": 0
+            },
+            "shape": "line",
+            "tags": [
+                "others"
+            ]
+        }
+    ]
+    blobAnnotations = [
+        {
+            "_id": "5",
+            "channel": 0,
+            "coordinates": [
+                {
+                    "x": 7,
+                    "y": 3,
+                    "z": 0
+                },
+                {
+                    "x": 9,
+                    "y": 5,
+                    "z": 0
+                },
+                {
+                    "x": 11,
+                    "y": 3,
+                    "z": 0
+                },
+                {
+                    "x": 9,
+                    "y": 1,
+                    "z": 0
+                }
+            ],
+            "datasetId": "111",
+            "location": {
+                "Time": 0,
+                "XY": 0,
+                "Z": 0
+            },
+            "shape": "polygon",
+            "tags": [
+                "other"
+            ]
+        },
+        {
+            "_id": "6",
+            "channel": 0,
+            "coordinates": [
+                {
+                    "x": 16,
+                    "y": 12,
+                    "z": 0
+                },
+                {
+                    "x": 18,
+                    "y": 14,
+                    "z": 0
+                },
+                {
+                    "x": 20,
+                    "y": 12,
+                    "z": 0
+                },
+                {
+                    "x": 18,
+                    "y": 10,
+                    "z": 0
+                }
+            ],
+            "datasetId": "111",
+            "location": {
+                "Time": 0,
+                "XY": 0,
+                "Z": 0
+            },
+            "shape": "polygon",
+            "tags": [
+                "others"
+            ]
+        }
+    ]
+    
+    def testIsAPoint(self):
+        assert isAPoint({"shape": "point"}) == True
+        assert isAPoint({"shape": "line"}) == False
+        assert isAPoint({"shape": "polygon"}) == False
+    
+    def testIsAPoly(self):
+        assert isAPoly({"shape": "point"}) == False
+        assert isAPoly({"shape": "line"}) == True
+        assert isAPoly({"shape": "polygon"}) == True
+
+    def testSimpleCentroid(self):
+        triangleCoordinates = [
+            {
+                "x": 6,
+                "y": 2,
+                "z": 0,
+            },
+            {
+                "x": 5,
+                "y": -9,
+                "z": 0,
+            },
+            {
+                "x": 2,
+                "y": -7,
+                "z": 0,
+            },
+        ]
+        centroid = simpleCentroid(triangleCoordinates)
+        assert centroid["x"] == 4.333333333333333
+        assert centroid["y"] == -4.666666666666667
+        
+    def testPointToPointDistance(self):
+        # TODO: Improve test
+        coordPoint1 = {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        }
+        
+        coordPoint2 = {
+            "x": 2,
+            "y": 0,
+            "z": 0
+        }
+        
+        assert pointToPointDistance(coordPoint1, coordPoint2) == 2
+       
+    def testAnnotationToAnnotationDistance(self):
+        distance = annotationToAnnotationDistance(self.pointAnnotations[0], self.pointAnnotations[1])
+        assert distance == math.sqrt(68)
+        distance = annotationToAnnotationDistance(self.pointAnnotations[0], self.lineAnnotations[0])
+        assert distance == 4
+        distance = annotationToAnnotationDistance(self.blobAnnotations[0], self.blobAnnotations[1])
+        assert distance == math.sqrt(162)
+
+    def testGetClosestAnnotation(self):
+        closest, _ = AnnotationConnection().getClosestAnnotation(self.pointAnnotationRef, self.pointAnnotations)
+        assert closest == self.pointAnnotations[1]
+        
+        closest, _ = AnnotationConnection().getClosestAnnotation(self.pointAnnotationRef, self.lineAnnotations)
+        assert closest == self.lineAnnotations[0]
+        
+        closest, _ = AnnotationConnection().getClosestAnnotation(self.pointAnnotationRef, self.blobAnnotations)
+        assert closest == self.blobAnnotations[0]
+        
+        annotations = self.pointAnnotations + self.lineAnnotations + self.blobAnnotations
+        annotations.append(self.pointAnnotationRef)
+        closest, _ = AnnotationConnection().getClosestAnnotation(self.pointAnnotationRef, annotations)
+        assert closest == self.pointAnnotations[1]
+        
+        closestPoint, minDistanceToPoint = AnnotationConnection().getClosestAnnotation(self.blobAnnotations[0], self.pointAnnotations)
+        assert closestPoint == self.pointAnnotations[0]
+        
+        closestLine, minDistanceToLine = AnnotationConnection().getClosestAnnotation(self.blobAnnotations[0], self.lineAnnotations)
+        assert closestLine == self.lineAnnotations[0]
+        
+        closestBlob, minDistanceToBlob = AnnotationConnection().getClosestAnnotation(self.blobAnnotations[0], self.blobAnnotations)
+        assert closestBlob == self.blobAnnotations[1]
+        
+        closest, minDistance = AnnotationConnection().getClosestAnnotation(self.blobAnnotations[0], annotations)
+        assert minDistance == min(minDistanceToPoint, minDistanceToLine, minDistanceToBlob)
+        assert closest == closestPoint

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
     image: mongo
     volumes:
       - "./db:/data/db"
+    ports:
+      - 27017:27017
 
   girder:
     build:

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -109,6 +109,10 @@ export default class AnnotationViewer extends Vue {
       : this.annotationStore.annotations;
   }
 
+  get annotationsConnections() {
+    return this.annotationStore.annotationConnections;
+  }
+
   get annotationIds() {
     return this.annotations.map((annotation: IAnnotation) => annotation.id);
   }
@@ -414,7 +418,7 @@ export default class AnnotationViewer extends Vue {
       (annotation: IAnnotation) => annotation.id
     );
 
-    this.annotationStore.annotationConnections
+    this.annotationsConnections
       .filter(
         (connection: IAnnotationConnection) =>
           !existingIds.includes(connection.id) &&
@@ -841,6 +845,7 @@ export default class AnnotationViewer extends Vue {
   }
 
   @Watch("annotations")
+  @Watch("annotationsConnections")
   onAnnotationsChanged() {
     this.drawAnnotations();
   }

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -691,64 +691,29 @@ export default class AnnotationViewer extends Vue {
     this.annotationLayer.addAnnotation(newGeoJSAnnotation, undefined, false);
   }
 
-  private async addAnnotationConnections(annotation: IAnnotation) {
+  private async addAnnotationConnections(
+    annotation: IAnnotation
+  ): Promise<IAnnotationConnection[]> {
     if (!this.selectedTool || !this.dataset) {
       return [];
     }
     const connectTo = this.selectedTool.values.connectTo;
     // Look for connections
     if (connectTo && connectTo.tags && connectTo.tags.length) {
-      const annotations = this.annotationStore.annotations;
       // Find eligible annotations (matching tags and channel)
       const connectToChannel =
         connectTo.layer === null ? null : this.layers[connectTo.layer].channel;
-      const eligibleAnnotations = annotations.filter((value: IAnnotation) => {
-        if (value.id === annotation.id) {
-          return false;
-        }
-        if (connectTo.layer !== null && value.channel !== connectToChannel) {
-          return false;
-        }
-        if (
-          annotation.location.XY !== value.location.XY ||
-          annotation.location.Z !== value.location.Z ||
-          annotation.location.Time !== value.location.Time
-        ) {
-          return false;
-        }
-        return value.tags.some(tag => connectTo.tags.includes(tag));
+      const connections = await this.annotationStore.createConnections({
+        annotationsIds: [annotation.id],
+        tags: this.selectedTool.values.connectTo.tags,
+        channelId: connectToChannel
       });
-      if (eligibleAnnotations.length) {
-        // Find the closest among eligible annotation
-        const sortedAnnotations = eligibleAnnotations.sort(
-          (valueA: IAnnotation, valueB: IAnnotation) => {
-            const distanceA = annotationDistance(valueA, annotation);
-            const distanceB = annotationDistance(valueB, annotation);
-            return distanceA - distanceB;
-          }
-        );
-        const [closest] = sortedAnnotations;
+      if (connections) {
+        connections.forEach((connection: any) => {
+          this.annotationStore.addConnection(connection);
+        });
 
-        // Create and add the new connection
-
-        const newConnection: IAnnotationConnection | null = await this.annotationStore.createConnection(
-          {
-            tags: [],
-            label: "A Connection",
-            parentId: closest.id,
-            childId: annotation.id,
-            datasetId: this.dataset.id
-          }
-        );
-        if (newConnection) {
-          this.annotationStore.addConnection(newConnection);
-          this.drawGeoJSAnnotationFromConnection(
-            newConnection,
-            annotation,
-            closest
-          );
-          return [newConnection];
-        }
+        return connections;
       }
     }
     return [];

--- a/src/store/AnnotationsAPI.ts
+++ b/src/store/AnnotationsAPI.ts
@@ -42,6 +42,22 @@ export default class AnnotationsAPI {
       });
   }
 
+  createConnections(
+    annotationsIds: string[],
+    tags: string[],
+    channelId: number | null
+  ): Promise<IAnnotationConnection[] | null> {
+    return this.client
+      .post("annotation_connection/connectTo", {
+        annotationsIds,
+        tags,
+        channelId
+      })
+      .then(res => {
+        return res.data.map((connection: any) => this.toConnection(connection));
+      });
+  }
+
   async getAnnotationsForDatasetId(id: string): Promise<IAnnotation[]> {
     const annotations: IAnnotation[] = [];
     const limit = 250;

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -208,6 +208,26 @@ export class Annotations extends VuexModule {
   }
 
   @Action
+  public async createConnections({
+    annotationsIds,
+    tags,
+    channelId
+  }: {
+    annotationsIds: string[];
+    tags: string[];
+    channelId: number|null;
+  }) {
+    sync.setSaving(true);
+    const connections = await this.annotationsAPI.createConnections(
+      annotationsIds,
+      tags,
+      channelId
+    );
+    sync.setSaving(false);
+    return connections;
+  }
+
+  @Action
   public async createConnection({
     parentId,
     childId,


### PR DESCRIPTION
@zjniu 
Here is the PR. If you can try it, and let me know if something is not working the way it should.
There is a new route: _annotation_connection/connectTo_ (from localhost: http://localhost:8080/api/v1/annotation_connection/connectTo)

Body content should be a json defined as below:
{
	"annotationsIds": [
		"id1",
		"id2",
		"idN"
	],
	"tags": ["tag1", "tag2"],
	"channelId": "0"
}

with (similar to what is done on front side):
- annotationsIds: a list of annotations ids you want to find connection with other annotations [1]
- tags: a list of tags to identify annotations that [1] should connect to
- channelId (optional  - because on front side you can select "Any")

