### PR TITLE
Add an endpoint to add multiple annotations

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -20,6 +20,7 @@ class Annotation(Resource):
         self.route('POST', (), self.create)
         self.route('PUT', (':id',), self.update)
         self.route('POST', ('compute',), self.compute)
+        self.route('POST', ('multiple',), self.createMultiple)
 
     # TODO: anytime a dataset is mentioned, load the dataset and check for existence and that the user has access to it
     # TODO: creation date, update date, creatorId
@@ -92,3 +93,14 @@ class Annotation(Resource):
         if not datasetId:
             raise RestException(code=400, message="Missing datasetId parameter")
         return self._annotationModel.compute(datasetId, self.getBodyJson(), self.getCurrentUser())
+
+    @access.user
+    @describeRoute(Description("Create multiple new annotations").param('body', 'Annotation Object', paramType='body'))
+    def createMultiple(self, params):
+        currentUser = self.getCurrentUser()
+        if not currentUser:
+            raise AccessException('User not found', 'currentUser')
+        annotations = self.getBodyJson().get("annotations", None)
+        if not annotations:
+            raise  RestException(code=400, message="Missing annotations to add")
+        return self._annotationModel.createMultiple(currentUser, annotations)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
@@ -147,3 +147,6 @@ class Annotation(AccessControlledModel):
     if not image:
         raise RestException(code=500, message="Invalid segmentation tool: no image")
     return runComputeJob(image, datasetId, tool)
+
+  def createMultiple(self, creator, annotations):
+    return [self.create(creator=creator, annotation=annotation) for annotation in annotations]


### PR DESCRIPTION
Added a new route:
_http://localhost:8080/api/v1/upenn_annotation/multiple_
Request body should look like:
{
	"annotations": [
		{
			"coordinates":[{
				"x": 0,
				"y": 0,
				"z": 0
			}],
			"tags": ["tag1", "tag2"],
			"channel": 0,
			"location": {
			        "XY": 0,
			        "Z": 0,
			        "Time": 0
		         },
			"shape": "point",
			"datasetId": "id"
		},
		{
			"coordinates":[{
				"x": 0,
				"y": 0,
				"z": 0
			}],
			"tags": ["tag1", "tag2"],
			"channel": 0,
			"location": {
			        "XY": 0,
			        "Z": 0,
			        "Time": 0
		         },
			"shape": "point",
			"datasetId": "id"
		},
	]	
}