### PR TITLE
Fix an issue when comparing histogram image lists.

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -955,7 +955,11 @@ export class Main extends VuexModule {
         }
         return null;
       };
-      if (images !== layer._histogram.images) {
+      if (
+        !layer._histogram.images ||
+        images.length !== layer._histogram.images.length ||
+        images.some((img, idx) => img !== layer._histogram.images[idx])
+      ) {
         layer._histogram.next = images;
         if (layer._histogram.last) {
           nextHistogram();


### PR DESCRIPTION
Specifically, Vue sometimes makes the image list an observable and then it doesn't compare with the non-observable list of the same items. Instead, compare the entries in the list.

This fixes #307.