### PR TITLE
Remove z coordinate from IGeoJSPoint

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/connections.py
@@ -3,7 +3,8 @@ import numpy as np
 
 def pointToPointDistance(coord1, coord2):
     """Get the distance between two points using points coordinates.
-    Points coordinates are represented by {x: x_coord, y: y_coord, z: z_coord}.
+    If both points have z coordinate, get the XYZ distance, else get the XY distance
+    Points coordinates are represented by {x: x_coord, y: y_coord, z?: z_coord}.
 
     Args:
         coord1 (dict): Coordinates of point 1
@@ -12,18 +13,20 @@ def pointToPointDistance(coord1, coord2):
     Returns:
         Number: Squared distance between point1 and point2
     """
-    return math.sqrt(
-      math.pow(coord1["x"] - coord2["x"], 2) + math.pow(coord1["y"] - coord2["y"], 2)
-    )
+    squareDist = math.pow(coord1["x"] - coord2["x"], 2) + math.pow(coord1["y"] - coord2["y"], 2)
+    if ("z" in coord1 and "z" in coord2):
+      squareDist += math.pow(coord1["z"] - coord2["z"], 2)
+    return math.sqrt(squareDist)
   
 
 def simpleCentroid(listCoordinates):
     """Compute the simple centroid of a polygon using its list of coordinates.
     The centroid corresponds to the barycenter of the polygon.
+    Compute centroid for z coordinate iff all points have z
 
     Args:
         listCoordinates (dict[]): List of point coordinates.
-          Point coordinates are represented by {x: x_coord, y: y_coord, z: z_coord}
+          Point coordinates are represented by {x: x_coord, y: y_coord, z?: z_coord}
 
     Returns:
         dict: Coordinates of the centroid
@@ -32,10 +35,18 @@ def simpleCentroid(listCoordinates):
     x = np.sum([coord["x"] for coord in listCoordinates]) / nbCoordinates
     y = np.sum([coord["y"] for coord in listCoordinates]) / nbCoordinates
 
-    return {
-      "x": x,
-      "y": y
-    }
+    if all(["z" in coord for coord in listCoordinates]):
+      z = np.sum([coord["z"] for coord in listCoordinates]) / nbCoordinates
+      return {
+        "x": x,
+        "y": y,
+        "z": z
+      }
+    else:
+      return {
+        "x": x,
+        "y": y
+      }
 
 def isAPoint(annotation):
   return annotation["shape"] == 'point'

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/connections.py
@@ -13,7 +13,7 @@ def pointToPointDistance(coord1, coord2):
         Number: Squared distance between point1 and point2
     """
     return math.sqrt(
-      math.pow(coord1["x"] - coord2["x"], 2) + math.pow(coord1["y"] - coord2["y"], 2) + math.pow(coord1["z"] - coord2["z"], 2)
+      math.pow(coord1["x"] - coord2["x"], 2) + math.pow(coord1["y"] - coord2["y"], 2)
     )
   
 
@@ -31,12 +31,10 @@ def simpleCentroid(listCoordinates):
     nbCoordinates = len(listCoordinates)
     x = np.sum([coord["x"] for coord in listCoordinates]) / nbCoordinates
     y = np.sum([coord["y"] for coord in listCoordinates]) / nbCoordinates
-    z = np.sum([coord["z"] for coord in listCoordinates]) / nbCoordinates
 
     return {
       "x": x,
-      "y": y,
-      "z": z
+      "y": y
     }
 
 def isAPoint(annotation):

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/connections.py
@@ -34,19 +34,16 @@ def simpleCentroid(listCoordinates):
     nbCoordinates = len(listCoordinates)
     x = np.sum([coord["x"] for coord in listCoordinates]) / nbCoordinates
     y = np.sum([coord["y"] for coord in listCoordinates]) / nbCoordinates
+    centroid = {
+      "x": x,
+      "y": y,
+    }
 
     if all(["z" in coord for coord in listCoordinates]):
       z = np.sum([coord["z"] for coord in listCoordinates]) / nbCoordinates
-      return {
-        "x": x,
-        "y": y,
-        "z": z
-      }
-    else:
-      return {
-        "x": x,
-        "y": y
-      }
+      centroid["z"] = z
+
+    return centroid
 
 def isAPoint(annotation):
   return annotation["shape"] == 'point'

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_connections.py
@@ -373,18 +373,15 @@ class TestConnectToNearest:
         triangleCoordinates = [
             {
                 "x": 6,
-                "y": 2,
-                "z": 0,
+                "y": 2
             },
             {
                 "x": 5,
-                "y": -9,
-                "z": 0,
+                "y": -9
             },
             {
                 "x": 2,
-                "y": -7,
-                "z": 0,
+                "y": -7
             },
         ]
         centroid = simpleCentroid(triangleCoordinates)
@@ -395,14 +392,12 @@ class TestConnectToNearest:
         # TODO: Improve test
         coordPoint1 = {
             "x": 0,
-            "y": 0,
-            "z": 0
+            "y": 0
         }
         
         coordPoint2 = {
             "x": 2,
-            "y": 0,
-            "z": 0
+            "y": 0
         }
         
         assert pointToPointDistance(coordPoint1, coordPoint2) == 2

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_connections.py
@@ -373,34 +373,126 @@ class TestConnectToNearest:
         triangleCoordinates = [
             {
                 "x": 6,
-                "y": 2
+                "y": 2,
+                "z": 0,
             },
             {
                 "x": 5,
-                "y": -9
+                "y": -9,
+                "z": 0,
             },
             {
                 "x": 2,
-                "y": -7
+                "y": -7,
+                "z": 0,
             },
         ]
         centroid = simpleCentroid(triangleCoordinates)
         assert centroid["x"] == 4.333333333333333
         assert centroid["y"] == -4.666666666666667
+        assert centroid["z"] == 0.0
+
+        triangleCoordinates = [
+            {
+                "x": 6,
+                "y": 2,
+            },
+            {
+                "x": 5,
+                "y": -9,
+                "z": 0,
+            },
+            {
+                "x": 2,
+                "y": -7,
+                "z": 0,
+            },
+        ]
+        centroid = simpleCentroid(triangleCoordinates)
+        assert centroid["x"] == 4.333333333333333
+        assert centroid["y"] == -4.666666666666667
+        assert not "z" in centroid
+
+        triangleCoordinates = [
+            {
+                "x": 6,
+                "y": 2,
+                "z": 1,
+            },
+            {
+                "x": 5,
+                "y": -9,
+                "z": 7,
+            },
+            {
+                "x": 2,
+                "y": -7,
+                "z": 4,
+            },
+        ]
+        centroid = simpleCentroid(triangleCoordinates)
+        assert centroid["x"] == 4.333333333333333
+        assert centroid["y"] == -4.666666666666667
+        assert centroid["z"] == 4.0
         
     def testPointToPointDistance(self):
-        # TODO: Improve test
         coordPoint1 = {
             "x": 0,
-            "y": 0
+            "y": 0,
+            "z": 0,
         }
-        
+        coordPoint2 = {
+            "x": 0,
+            "y": 0,
+            "z": 2,
+        }
+        assert pointToPointDistance(coordPoint1, coordPoint2) == 2
+
+        coordPoint1 = {
+            "x": 0,
+            "y": 0,
+        }
+        coordPoint2 = {
+            "x": 4,
+            "y": 0,
+            "z": 10,
+        }
+        assert pointToPointDistance(coordPoint1, coordPoint2) == 4
+
+        coordPoint1 = {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+        }
+        coordPoint2 = {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+        }
+        assert pointToPointDistance(coordPoint1, coordPoint2) == 0
+
+        coordPoint1 = {
+            "x": 3,
+            "y": 0,
+            "z": 5,
+        }
+        coordPoint2 = {
+            "x": 0,
+            "y": -5,
+        }
+        assert abs(pointToPointDistance(coordPoint1, coordPoint2) - math.sqrt(34)) < 0.000000000000001
+
+        coordPoint1 = {
+            "x": 1,
+            "y": 4,
+            "z": -6,
+        }
         coordPoint2 = {
             "x": 2,
-            "y": 0
+            "y": 10,
+            "z": -10,
         }
-        
-        assert pointToPointDistance(coordPoint1, coordPoint2) == 2
+        assert abs(pointToPointDistance(coordPoint1, coordPoint2) - math.sqrt(53)) < 0.000000000000001
        
     def testAnnotationToAnnotationDistance(self):
         distance = annotationToAnnotationDistance(self.pointAnnotations[0], self.pointAnnotations[1])

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -285,8 +285,7 @@ export default class AnnotationViewer extends Vue {
 
       return annotation.coordinates.map((point: IGeoJSPoint) => ({
         x: tileW * tileX + point.x,
-        y: tileH * tileY + point.y,
-        z: point.z
+        y: tileH * tileY + point.y
       }));
     }
     return annotation.coordinates;
@@ -354,6 +353,10 @@ export default class AnnotationViewer extends Vue {
       // One text feature per line as in https://opengeoscience.github.io/geojs/tutorials/text/
       // Centroid is computed once per new line (optimization needed?)
       // TODO: More performance with renderThreshold https://opengeoscience.github.io/geojs/apidocs/geo.textFeature.html#.styleSpec
+      const anyImage = this.store.dataset?.anyImage();
+      if (!anyImage) {
+        return;
+      }
       const baseStyle = {
         fontSize: "12px",
         fontFamily: "sans-serif",
@@ -367,7 +370,7 @@ export default class AnnotationViewer extends Vue {
         .createFeature("text")
         .data(displayedAnnotations)
         .position((annotation: IAnnotation) => {
-          return simpleCentroid(annotation.coordinates);
+          return simpleCentroid(this.unrolledCoordinates(annotation, anyImage));
         })
         .style({
           text: (annotation: IAnnotation) => {
@@ -387,7 +390,7 @@ export default class AnnotationViewer extends Vue {
         .createFeature("text")
         .data(displayedAnnotations)
         .position((annotation: IAnnotation) => {
-          return simpleCentroid(annotation.coordinates);
+          return simpleCentroid(this.unrolledCoordinates(annotation, anyImage));
         })
         .style({
           text: (annotation: IAnnotation) => {

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -285,7 +285,8 @@ export default class AnnotationViewer extends Vue {
 
       return annotation.coordinates.map((point: IGeoJSPoint) => ({
         x: tileW * tileX + point.x,
-        y: tileH * tileY + point.y
+        y: tileH * tileY + point.y,
+        z: point.z
       }));
     }
     return annotation.coordinates;

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -156,7 +156,6 @@ export interface IDisplayLayer {
 export interface IGeoJSPoint {
   x: number;
   y: number;
-  z: number;
 }
 
 export interface IWorkerInterface {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -156,6 +156,7 @@ export interface IDisplayLayer {
 export interface IGeoJSPoint {
   x: number;
   y: number;
+  z?: number; // Optional z coordinate
 }
 
 export interface IWorkerInterface {

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -96,7 +96,8 @@ export function simpleCentroid(coordinates: IGeoJSPoint[]): IGeoJSPoint {
   coordinates.forEach(({ x, y, z }) => {
     sums.x += x;
     sums.y += y;
-    if (z !== undefined) {
+    if (hasZ) {
+      // @ts-ignore
       sums.z += z;
     }
   });

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -101,18 +101,14 @@ export function simpleCentroid(coordinates: IGeoJSPoint[]): IGeoJSPoint {
       sums.z += z;
     }
   });
+  const centroid: IGeoJSPoint = {
+    x: sums.x / coordinates.length,
+    y: sums.y / coordinates.length
+  };
   if (hasZ) {
-    return {
-      x: sums.x / coordinates.length,
-      y: sums.y / coordinates.length,
-      z: sums.z / coordinates.length
-    };
-  } else {
-    return {
-      x: sums.x / coordinates.length,
-      y: sums.y / coordinates.length
-    };
+    centroid.z = sums.z / coordinates.length;
   }
+  return centroid;
 }
 
 export function pointDistance(a: IGeoJSPoint, b: IGeoJSPoint) {

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -91,16 +91,14 @@ export function simpleCentroid(coordinates: IGeoJSPoint[]): IGeoJSPoint {
   if (coordinates.length === 1) {
     return coordinates[0];
   }
-  const sums: IGeoJSPoint = { x: 0, y: 0, z: 0 };
-  coordinates.forEach(({ x, y, z }) => {
+  const sums: IGeoJSPoint = { x: 0, y: 0 };
+  coordinates.forEach(({ x, y }) => {
     sums.x += x;
     sums.y += y;
-    sums.z += z;
   });
   return {
     x: sums.x / coordinates.length,
-    y: sums.y / coordinates.length,
-    z: sums.z / coordinates.length
+    y: sums.y / coordinates.length
   };
 }
 

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -92,7 +92,7 @@ export function simpleCentroid(coordinates: IGeoJSPoint[]): IGeoJSPoint {
     return coordinates[0];
   }
   const sums = { x: 0, y: 0, z: 0 };
-  const allZ = !coordinates.some(coord => coord.z === undefined);
+  const hasZ = coordinates.every(coord => coord.z !== undefined);
   coordinates.forEach(({ x, y, z }) => {
     sums.x += x;
     sums.y += y;
@@ -100,7 +100,7 @@ export function simpleCentroid(coordinates: IGeoJSPoint[]): IGeoJSPoint {
       sums.z += z;
     }
   });
-  if (allZ) {
+  if (hasZ) {
     return {
       x: sums.x / coordinates.length,
       y: sums.y / coordinates.length,

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -91,15 +91,27 @@ export function simpleCentroid(coordinates: IGeoJSPoint[]): IGeoJSPoint {
   if (coordinates.length === 1) {
     return coordinates[0];
   }
-  const sums: IGeoJSPoint = { x: 0, y: 0 };
-  coordinates.forEach(({ x, y }) => {
+  const sums = { x: 0, y: 0, z: 0 };
+  const allZ = !coordinates.some(coord => coord.z === undefined);
+  coordinates.forEach(({ x, y, z }) => {
     sums.x += x;
     sums.y += y;
+    if (z !== undefined) {
+      sums.z += z;
+    }
   });
-  return {
-    x: sums.x / coordinates.length,
-    y: sums.y / coordinates.length
-  };
+  if (allZ) {
+    return {
+      x: sums.x / coordinates.length,
+      y: sums.y / coordinates.length,
+      z: sums.z / coordinates.length
+    };
+  } else {
+    return {
+      x: sums.x / coordinates.length,
+      y: sums.y / coordinates.length
+    };
+  }
 }
 
 export function pointDistance(a: IGeoJSPoint, b: IGeoJSPoint) {


### PR DESCRIPTION
Z coordinate of IGeoJSPoint was used inconsistently, being often undefined and causing bugs.
Closes [#304](https://github.com/Kitware/UPennContrast/issues/304)