### PR TITLE
Clean the debounce of getLayerHistogram

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -967,11 +967,8 @@ export class Main extends VuexModule {
         return null;
       };
 
-      const imagesToId = (images: IImage[] | null) => {
-        return (
-          images?.map(i => `${i.item._id}#${i.frameIndex}`).join(",") || "null"
-        );
-      };
+      const imagesToId = (images: IImage[] | null) =>
+        images?.map(i => `${i.item._id}#${i.frameIndex}`).join(",") || "null";
 
       if (imagesToId(images) !== imagesToId(layer._histogram.lastImages)) {
         layer._histogram.nextImages = images;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -968,7 +968,7 @@ export class Main extends VuexModule {
       };
 
       const imagesToId = (images: IImage[] | null) =>
-        images?.map(i => `${i.item._id}#${i.frameIndex}`).join(",") || "null";
+        images?.map(i => `${i.item._id}#${i.frameIndex}`).join(",");
 
       if (imagesToId(images) !== imagesToId(layer._histogram.lastImages)) {
         layer._histogram.nextImages = images;

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1,4 +1,5 @@
 import { IGirderItem, IGirderFolder } from "@/girder";
+import { ITileHistogram } from "./images";
 
 export interface IDatasetConfigurationMeta {
   id: string;
@@ -150,7 +151,13 @@ export interface IDisplayLayer {
 
   contrast: IContrast;
 
-  _histogram?: any | undefined;
+  _histogram?: {
+    promise: Promise<null | ITileHistogram>;
+    lastHistogram: null | ITileHistogram;
+    lastImages: IImage[] | null;
+    nextImages: IImage[] | null;
+    lock: boolean;
+  };
 }
 
 export interface IGeoJSPoint {


### PR DESCRIPTION
Reformat getLayerHistogram to make it clearer.
Fix an infinite recursion.

Closes [#310](https://github.com/Kitware/UPennContrast/issues/310)