### PR TITLE
Replace annotation channel with layerId

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
@@ -63,12 +63,12 @@ class AnnotationSchema:
             },
             'coordinates': coordsSchema,
             'tags': tagsSchema,
-            'channel': {'type': 'integer'},
+            'layerId': {'type': 'string'},
             'location': locationSchema,
             'shape': shapeSchema,
             'datasetId': {'type': 'string', 'minLength': 1},
         },
-        'required': ['coordinates', 'tags', 'channel', 'location', 'shape', 'datasetId']
+        'required': ['coordinates', 'tags', 'layerId', 'location', 'shape', 'datasetId']
     }
 
 class Annotation(AccessControlledModel):

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/upenn_testing_utilities.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/upenn_testing_utilities.py
@@ -8,7 +8,7 @@ sampleAnnotation = {
     "tags": ["tag"],
     "shape": "point",
     "name": sampleAnnotationName,
-    "channel": 0,
+    "layerId": "Brightfield",
     "location": {
         "XY": 0,
         "Z": 0,

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -97,13 +97,13 @@ export default class AnnotationCsvDialog extends Vue {
   }
 
   async generateCSVStringForAnnotations() {
-    let text = "Id, Channel, XY, Z, Time, Tags, Shape";
+    let text = "Id, Layer Id, XY, Z, Time, Tags, Shape";
     this.propertyIds?.forEach((id: string) => {
       text += `, ${id}`;
     });
 
     (this.annotations as IAnnotation[]).forEach((annotation: IAnnotation) => {
-      text += `\n${annotation.id}, ${annotation.channel}, ${
+      text += `\n${annotation.id}, ${annotation.layerId}, ${
         annotation.location.XY
       }, ${annotation.location.Z}, ${
         annotation.location.Time

--- a/src/store/AnnotationsAPI.ts
+++ b/src/store/AnnotationsAPI.ts
@@ -21,7 +21,7 @@ export default class AnnotationsAPI {
   createAnnotation(
     tags: string[],
     shape: string,
-    channel: number,
+    layerId: string,
     location: { XY: number; Z: number; Time: number },
     coordinates: IGeoJSPoint[],
     datasetId: string
@@ -30,7 +30,7 @@ export default class AnnotationsAPI {
       .post("upenn_annotation", {
         tags,
         shape,
-        channel,
+        layerId,
         location,
         coordinates,
         datasetId
@@ -109,7 +109,7 @@ export default class AnnotationsAPI {
       name,
       tags,
       shape,
-      channel,
+      layerId,
       location,
       coordinates,
       _id,
@@ -119,7 +119,7 @@ export default class AnnotationsAPI {
       name,
       tags,
       shape,
-      channel,
+      layerId,
       location,
       coordinates,
       id: _id,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -982,6 +982,11 @@ export class Main extends VuexModule {
     };
   }
 
+  get getLayerFromId() {
+    return (layerId: string) =>
+      this.configuration?.view.layers.find(layer => layer.id === layerId);
+  }
+
   @Mutation
   public setSnapshotImpl(value?: string) {
     // check if snapshot is available.  If not, set to undefined

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -197,7 +197,7 @@ export interface IAnnotation {
   id: string;
   tags: string[];
   name: string | null;
-  channel: number;
+  layerId: string;
   location: IAnnotationLocation;
   shape: AnnotationShape;
   coordinates: IGeoJSPoint[];

--- a/src/tools/creation/templates/AnnotationConfiguration.vue
+++ b/src/tools/creation/templates/AnnotationConfiguration.vue
@@ -96,14 +96,6 @@ export default class AnnotationConfiguration extends Vue {
   get dataset() {
     return this.store.dataset;
   }
-  get channels() {
-    return (
-      this.dataset?.channels.map(channelId => ({
-        value: channelId,
-        text: this.dataset?.channelNames.get(channelId)
-      })) || []
-    );
-  }
 
   tagSearchInput: string = "";
 


### PR DESCRIPTION
This is a breaking change as the server side annotations don't have the same model anymore.
Annotations had a property "channel" but the user input a layer.
Replace the property "channel" with a "layerId" as a channel can be retrieved from the layer ID.

As the user can change the channel of a layer, he can then change the channel of an annotation.

When the user deletes a layer, it doesn't delete the annotations linked to the layer but they can't be seen them anymore.
Should the linked annotations be deleted too?
Maybe open a dialogue to ask the user wether he wants to replace the layer of all annotations to be deleted, or delete them

Closes #310