### PR TITLE
Bring to annotation in the browser on click in the view

### DIFF
--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -16,6 +16,17 @@
       ></annotation-csv-dialog>
     </v-expansion-panel-header>
     <v-expansion-panel-content>
+      <v-dialog v-model="annotationFilteredDialog">
+        <v-card>
+          <v-card-title>
+            Annotation does not pass current filtering criteria
+          </v-card-title>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn @click.native="annotationFilteredDialog = false">OK</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
       <v-data-table
         :items="filtered"
         :headers="headers"
@@ -116,6 +127,8 @@ export default class AnnotationList extends Vue {
   tableItemClass = "px-1"; // To enable dividers, use v-data-table__divider
 
   tableOptions: any = {};
+
+  annotationFilteredDialog: boolean = false;
 
   // TODO: clean up selected after filter changes
   get selected() {
@@ -233,11 +246,11 @@ export default class AnnotationList extends Vue {
       annotation => annotation.id === this.hoveredId
     );
     if (entryIndex < 0) {
+      this.annotationFilteredDialog = true;
       return;
     }
     this.tableOptions.page =
       Math.floor(entryIndex / this.tableOptions.itemsPerPage) + 1;
-    console.log(this.tableOptions);
     // Get the tr element from the refs if it exists
     let annotationRef = this.$refs[this.hoveredId];
     if (annotationRef === undefined) {
@@ -287,6 +300,10 @@ tbody tr.is-hovered:hover {
   min-height: 0 !important;
   display: flex !important;
   align-items: center !important;
+}
+
+.v-dialog {
+  width: 50%;
 }
 
 .v-input--selection-controls {

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -1057,7 +1057,11 @@ export default class AnnotationViewer extends Vue {
             unitsPerPixel
           )
         ) {
-          this.annotationStore.setHoveredAnnotationId(id);
+          if (this.annotationStore.hoveredAnnotationId === id) {
+            this.annotationStore.setHoveredAnnotationId(null);
+          } else {
+            this.annotationStore.setHoveredAnnotationId(id);
+          }
           return true;
         } else {
           return false;
@@ -1222,7 +1226,7 @@ export default class AnnotationViewer extends Vue {
     this.filterStore.updateHistograms();
 
     this.annotationLayer.geoOn(geojs.event.mouseclick, (evt: any) => {
-      if (evt?.geo) {
+      if (this.selectedTool === null && evt?.geo) {
         this.setHoveredAnnotationFromCoordinates(evt.geo);
       }
     });

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -1035,31 +1035,35 @@ export default class AnnotationViewer extends Vue {
     }
   }
 
-  handleMouseOver(evt: any) {
-    if (!evt || this.selectedTool) {
-      return;
-    }
-    let annotation = evt?.data?.annotation;
-    if (!annotation && evt?.data?.length) {
-      annotation = evt.data[0][2].annotation;
-    }
-    if (annotation && annotation.options("girderId")) {
-      this.annotationStore.setHoveredAnnotationId(
-        annotation.options("girderId")
-      );
-    }
-  }
-
-  handleMouseOff(evt: any) {
-    let annotation = evt?.data?.annotation;
-    if (!annotation && evt?.data?.length) {
-      annotation = evt.data[0][2].annotation;
-    }
-    if (
-      annotation &&
-      annotation.options("girderId") &&
-      this.hoveredAnnotationId === annotation.options("girderId")
-    ) {
+  setHoveredAnnotationFromCoordinates(gcsCoordinates: IGeoJSPoint) {
+    const hasSet = this.annotationLayer
+      .annotations()
+      .some((geoJSAnnotation: any) => {
+        const id = geoJSAnnotation.options("girderId");
+        if (!id) {
+          return false;
+        }
+        const annotation = this.getAnnotationFromId(id);
+        if (!annotation) {
+          return false;
+        }
+        const unitsPerPixel = this.getMapUnitsPerPixel();
+        if (
+          this.shouldSelectAnnotation(
+            AnnotationShape.Point,
+            [gcsCoordinates],
+            annotation,
+            geoJSAnnotation.style(),
+            unitsPerPixel
+          )
+        ) {
+          this.annotationStore.setHoveredAnnotationId(id);
+          return true;
+        } else {
+          return false;
+        }
+      });
+    if (!hasSet) {
       this.annotationStore.setHoveredAnnotationId(null);
     }
   }
@@ -1070,16 +1074,6 @@ export default class AnnotationViewer extends Vue {
   }
 
   handleAnnotationChange(evt: any) {
-    this.annotationLayer
-      .features()
-      .filter((feature: any) => !feature.selectionAPI())
-      .forEach((feature: any) => {
-        feature.selectionAPI(true);
-        feature.geoOff(geojs.event.feature.mouseon, this.handleMouseOver);
-        feature.geoOff(geojs.event.feature.mouseoff, this.handleMouseOff);
-        feature.geoOn(geojs.event.feature.mouseon, this.handleMouseOver);
-        feature.geoOn(geojs.event.feature.mouseoff, this.handleMouseOff);
-      });
     if (!this.selectedTool && !this.roiFilter) {
       return;
     }
@@ -1226,6 +1220,12 @@ export default class AnnotationViewer extends Vue {
     this.propertiesStore.fetchProperties();
     this.propertiesStore.fetchPropertyValues();
     this.filterStore.updateHistograms();
+
+    this.annotationLayer.geoOn(geojs.event.mouseclick, (evt: any) => {
+      if (evt?.geo) {
+        this.setHoveredAnnotationFromCoordinates(evt.geo);
+      }
+    });
   }
 }
 </script>

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -19,25 +19,21 @@ export function getAnnotationStyleFromLayer(
     strokeColor: "black",
     strokeOpacity: 1,
     strokeWidth: 2,
-    fillColor: "#white",
+    fillColor: "white",
     fillOpacity: 0.5,
     fill: true,
     radius: 10
   };
-  if (!layer) {
-    return style;
-  }
 
   if (layer) {
     style.fillColor = layer.color;
     style.strokeColor = layer.color;
   }
-  if (isHovered) {
-    style.radius = 13;
-  }
   if (isSelected) {
-    style.fillOpacity = 0.3;
     style.strokeWidth = 5;
+  }
+  if (isHovered) {
+    style.fillOpacity = 0;
   }
   return style;
 }


### PR DESCRIPTION
When clicking in the view, the annotation becomes hovered if no tool is selected
Scroll to annotation in the browse annotation panel when clicking an annotation
Fix minor style bug on hover

Closes #322 
Closes #321 