### PR TITLE
Add import/export feature

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
@@ -20,6 +20,7 @@ class AnnotationConnection(Resource):
         self.route('POST', (), self.create)
         self.route('PUT', (':id',), self.update)
         self.route('POST',('connectTo',) , self.connectToNearest)
+        self.route('POST', ('multiple',), self.multipleCreate)
 
     # TODO: anytime a dataset is mentioned, load the dataset and check for existence and that the user has access to it
     # TODO: load both childe and parent annotations, and check that they share existence, access and location
@@ -33,6 +34,14 @@ class AnnotationConnection(Resource):
         if not currentUser:
             raise AccessException('User not found', 'currentUser')
         return self._connectionModel.create(currentUser, self.getBodyJson())
+
+    @access.user
+    @describeRoute(Description("Create multiple new connections").param('body', 'Connection Object List', paramType='body'))
+    def multipleCreate(self, params):
+        currentUser = self.getCurrentUser()
+        if not currentUser:
+            raise AccessException('User not found', 'currentUser')
+        return [self._connectionModel.create(currentUser, connection) for connection in self.getBodyJson()]
 
     @describeRoute(Description("Delete an existing connection").param('id', 'The connection\'s Id', paramType='path').errorResponse('ID was invalid.')
                    .errorResponse('Write access was denied for the connection.', 403))

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="dialog">
     <template v-slot:activator="{ on, attrs }">
-      <v-btn v-bind="attrs" v-on="on">
+      <v-btn v-bind="{ ...attrs, ...$attrs }" v-on="on">
         <v-icon>mdi-application-export</v-icon>
         EXPORT CSV
       </v-btn>
@@ -47,6 +47,7 @@ import propertyStore from "@/store/properties";
 import filterStore from "@/store/filters";
 
 import { IAnnotation } from "@/store/model";
+import { downloadToClient } from "@/utils/download";
 
 @Component({
   components: {}
@@ -130,19 +131,11 @@ export default class AnnotationCsvDialog extends Vue {
   }
 
   download() {
-    const element = document.createElement("a");
-    element.setAttribute(
-      "href",
-      "data:text/plain;charset=utf-8," + encodeURIComponent(this.text)
-    );
-    element.setAttribute("download", "upenn_annotation_export.csv");
-
-    element.style.display = "none";
-    document.body.appendChild(element);
-
-    element.click();
-
-    document.body.removeChild(element);
+    const params = {
+      href: "data:text/plain;charset=utf-8," + encodeURIComponent(this.text),
+      download: "upenn_annotation_export.csv"
+    };
+    downloadToClient(params);
   }
 }
 </script>

--- a/src/components/AnnotationBrowser/AnnotationExport.vue
+++ b/src/components/AnnotationBrowser/AnnotationExport.vue
@@ -1,0 +1,120 @@
+<template>
+  <v-dialog v-model="dialog">
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn v-bind="{ ...attrs, ...$attrs }" v-on="on">
+        <v-icon>mdi-export</v-icon>
+        Export to JSON
+      </v-btn>
+    </template>
+    <v-card class="pa-2" :disabled="!canExport">
+      <v-card-title>
+        Export
+      </v-card-title>
+      <v-card-text class="pt-5 pb-0">
+        <v-checkbox v-model="exportAnnotations" label="Export annotations" />
+        <v-checkbox
+          v-model="exportConnections"
+          :disabled="!exportAnnotations"
+          label="Export annotation connections"
+        />
+        <v-checkbox v-model="exportProperties" label="Export properties" />
+        <v-checkbox
+          v-model="exportValues"
+          :disabled="!exportProperties || !exportAnnotations"
+          label="Export property values"
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn @click="submit" color="primary">
+          Export selection
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from "vue-property-decorator";
+import store from "@/store";
+
+import {
+  IAnnotation,
+  IAnnotationConnection,
+  IAnnotationProperty,
+  IAnnotationPropertyValues,
+  ISerializedData
+} from "@/store/model";
+import { downloadToClient } from "@/utils/download";
+
+@Component({})
+export default class AnnotationImport extends Vue {
+  readonly store = store;
+
+  dialog = false;
+
+  exportAnnotations = true;
+  exportConnections = true;
+  exportProperties = true;
+  exportValues = true;
+
+  get canExport() {
+    return !!store.dataset;
+  }
+
+  submit() {
+    let annotationPromise: Promise<IAnnotation[]> = Promise.resolve([]);
+    if (this.exportAnnotations) {
+      annotationPromise = store.annotationsAPI.getAnnotationsForDatasetId(
+        store.dataset!.id
+      );
+    }
+
+    let connectionsPromise: Promise<IAnnotationConnection[]> = Promise.resolve(
+      []
+    );
+    if (this.exportConnections && this.exportAnnotations) {
+      connectionsPromise = store.annotationsAPI.getConnectionsForDatasetId(
+        store.dataset!.id
+      );
+    }
+
+    let propertiesPromise: Promise<IAnnotationProperty[]> = Promise.resolve([]);
+    if (this.exportProperties) {
+      propertiesPromise = store.propertiesAPI.getProperties();
+    }
+
+    let valuesPromise: Promise<IAnnotationPropertyValues> = Promise.resolve({});
+    if (this.exportValues) {
+      valuesPromise = store.propertiesAPI.getPropertyValues(store.dataset!.id);
+    }
+
+    Promise.all([
+      annotationPromise,
+      connectionsPromise,
+      propertiesPromise,
+      valuesPromise
+    ]).then(
+      ([
+        annotations,
+        annotationConnections,
+        annotationProperties,
+        annotationPropertyValues
+      ]) => {
+        const serializable: ISerializedData = {
+          annotations,
+          annotationConnections,
+          annotationProperties,
+          annotationPropertyValues
+        };
+        const href =
+          "data:text/plain;charset=utf-8," +
+          encodeURIComponent(JSON.stringify(serializable));
+
+        downloadToClient({ href, download: "upennExport.json" });
+        this.dialog = false;
+      }
+    );
+  }
+}
+</script>

--- a/src/components/AnnotationBrowser/AnnotationImport.vue
+++ b/src/components/AnnotationBrowser/AnnotationImport.vue
@@ -1,0 +1,359 @@
+<template>
+  <v-dialog v-model="dialog">
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn v-bind="{ ...attrs, ...$attrs }" v-on="on">
+        <v-icon>mdi-import</v-icon>
+        Import JSON
+      </v-btn>
+    </template>
+    <v-card class="pa-2" :disabled="!canImport">
+      <v-card-title>
+        Import
+      </v-card-title>
+      <v-card-text class="pt-5 pb-0">
+        <v-file-input
+          accept="application/JSON"
+          prepend-icon="mdi-code-json"
+          label="JSON file"
+          v-model="jsonFile"
+        />
+        <v-progress-circular v-if="isLoadingFile" indeterminate />
+        <div v-if="isJsonLoaded">
+          <div class="pa-2">
+            <v-checkbox
+              v-model="importAnnotations"
+              :label="`Import ${annotations.length} annotations`"
+            />
+            <v-checkbox
+              v-model="importConnections"
+              :disabled="!importAnnotations"
+              :label="`Import ${connections.length} annotation connections`"
+            />
+            <v-checkbox
+              v-model="importProperties"
+              :label="`Import ${properties.length} properties`"
+            />
+            <v-checkbox
+              v-model="importValues"
+              :disabled="!importProperties || !importAnnotations"
+              :label="
+                `Import property values of ${
+                  Object.keys(values).length
+                } annotations`
+              "
+            />
+          </div>
+          <div class="pa-2">
+            <v-checkbox
+              v-model="overwriteAnnotations"
+              :label="
+                `Overwrite ${annotationStore.annotations.length} annotations (delete current annotations)`
+              "
+              @change="overwriteChanged"
+            />
+            <v-dialog v-model="overwriteDialog" persistent>
+              <v-card class="pa-2">
+                <v-card-title>
+                  Overwrite annotations?
+                </v-card-title>
+                <v-card-text>
+                  This will remove
+                  {{ annotationStore.annotations.length }} annotations forever
+                </v-card-text>
+                <v-card-actions>
+                  <v-spacer />
+                  <v-btn
+                    @click="
+                      overwriteAnnotations = true;
+                      overwriteDialog = false;
+                    "
+                    color="warning"
+                  >
+                    Overwrite
+                  </v-btn>
+                  <v-btn
+                    @click="
+                      overwriteAnnotations = false;
+                      overwriteDialog = false;
+                    "
+                    color="primary"
+                  >
+                    Cancel
+                  </v-btn>
+                </v-card-actions>
+              </v-card>
+            </v-dialog>
+          </div>
+        </div>
+      </v-card-text>
+      <v-card-actions v-if="isJsonLoaded">
+        <v-spacer />
+        <v-progress-circular v-if="isImporting" indeterminate />
+        <v-btn @click="submit" color="primary">
+          Import selection
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Watch } from "vue-property-decorator";
+import store from "@/store";
+import annotationStore from "@/store/annotation";
+import propertyStore from "@/store/properties";
+
+import {
+  IAnnotation,
+  IAnnotationBase,
+  IAnnotationConnection,
+  IAnnotationConnectionBase,
+  IAnnotationProperty,
+  IAnnotationPropertyValues,
+  ISerializedData
+} from "@/store/model";
+
+@Component({})
+export default class AnnotationImport extends Vue {
+  readonly store = store;
+  readonly annotationStore = annotationStore;
+  readonly propertyStore = propertyStore;
+
+  dialog = false;
+  overwriteDialog = false;
+
+  jsonFile: File | null = null;
+  isLoadingFile = false;
+  isJsonLoaded = false;
+  isImporting = false;
+
+  annotations: IAnnotation[] = [];
+  connections: IAnnotationConnection[] = [];
+  properties: IAnnotationProperty[] = [];
+  values: IAnnotationPropertyValues = {};
+
+  importAnnotations = true;
+  importConnections = true;
+  importProperties = true;
+  importValues = true;
+  overwriteAnnotations = false;
+
+  get canImport() {
+    return !!store.dataset;
+  }
+
+  @Watch("jsonFile")
+  getJsonContent() {
+    this.isJsonLoaded = false;
+    this.annotations = [];
+    this.connections = [];
+    this.properties = [];
+    this.values = {};
+    if (!this.jsonFile) {
+      return;
+    }
+    this.isLoadingFile = true;
+    this.jsonFile
+      .text()
+      .then(jsonText => {
+        ({
+          annotations: this.annotations,
+          annotationConnections: this.connections,
+          annotationProperties: this.properties,
+          annotationPropertyValues: this.values
+        } = JSON.parse(jsonText) as ISerializedData);
+        this.isJsonLoaded = true;
+      })
+      .catch(() => {
+        this.jsonFile = null;
+      })
+      .finally(() => (this.isLoadingFile = false));
+  }
+
+  overwriteChanged() {
+    if (this.overwriteAnnotations) {
+      this.overwriteDialog = true;
+    }
+  }
+
+  reset() {
+    this.dialog = false;
+    this.overwriteDialog = false;
+
+    this.jsonFile = null;
+    this.isLoadingFile = false;
+    this.isJsonLoaded = false;
+    this.isImporting = false;
+
+    this.annotations = [];
+    this.connections = [];
+    this.properties = [];
+    this.values = {};
+
+    this.importAnnotations = true;
+    this.importConnections = true;
+    this.importProperties = true;
+    this.importValues = true;
+    this.overwriteAnnotations = false;
+  }
+
+  async submit() {
+    let annotationIdsToRemove: string[] = [];
+    if (this.overwriteAnnotations) {
+      for (const { id } of annotationStore.annotations) {
+        annotationIdsToRemove.push(id);
+      }
+    }
+
+    // Import annotations
+    // promise of: old annotation id -> new annotation
+    let allAnnotationsPromise: Promise<Map<
+      string,
+      IAnnotation
+    >> = Promise.resolve(new Map());
+    if (this.importAnnotations) {
+      const annotationBaseList: IAnnotationBase[] = [];
+      for (let arrayIdx = 0; arrayIdx < this.annotations.length; arrayIdx++) {
+        const oldAnnotation = this.annotations[arrayIdx];
+        annotationBaseList.push({
+          tags: oldAnnotation.tags,
+          shape: oldAnnotation.shape,
+          channel: oldAnnotation.channel,
+          location: oldAnnotation.location,
+          coordinates: oldAnnotation.coordinates,
+          datasetId: this.store.dataset!.id
+        });
+      }
+      allAnnotationsPromise = this.store.annotationsAPI
+        .createMultipleAnnotations(annotationBaseList)
+        .then(newAnnotations => {
+          const oldIdToNewAnnotation: Map<string, IAnnotation> = new Map();
+          if (newAnnotations === null) {
+            return oldIdToNewAnnotation;
+          }
+          for (
+            let arrayIdx = 0;
+            arrayIdx < this.annotations.length;
+            arrayIdx++
+          ) {
+            const oldAnnotation = this.annotations[arrayIdx];
+            const newAnnotation = newAnnotations[arrayIdx];
+            oldIdToNewAnnotation.set(oldAnnotation.id, newAnnotation);
+          }
+          return oldIdToNewAnnotation;
+        });
+    }
+
+    // Import annotation connections
+    let allConnectionsPromise: Promise<
+      IAnnotationConnection[] | null
+    > = Promise.resolve(null);
+    if (this.importAnnotations && this.importConnections) {
+      // Need all annotations to be sent before sending connections
+      allAnnotationsPromise.then(oldIdToNewAnnotation => {
+        const annotationConnectionBaseList: IAnnotationConnectionBase[] = [];
+        for (const connection of this.connections) {
+          const parent = oldIdToNewAnnotation.get(connection.parentId);
+          const child = oldIdToNewAnnotation.get(connection.childId);
+          if (parent && child) {
+            annotationConnectionBaseList.push({
+              parentId: parent.id,
+              childId: child.id,
+              label: connection.label,
+              tags: connection.tags,
+              datasetId: this.store.dataset!.id
+            });
+          } else {
+            throw "Can't find the parent or the child of the connection to create";
+          }
+        }
+        allConnectionsPromise = this.store.annotationsAPI.createMultipleConnections(
+          annotationConnectionBaseList
+        );
+      });
+    }
+
+    // Import properties
+    const propertyPromises: Promise<IAnnotationProperty>[] = [];
+    const propertyOldIdToIdx: { [oldId: string]: number } = {};
+    if (this.importProperties) {
+      for (const oldProperty of this.properties) {
+        const newPropertyPromise = this.store.propertiesAPI.createProperty(
+          oldProperty
+        );
+        const idx = propertyPromises.push(newPropertyPromise) - 1;
+        propertyOldIdToIdx[oldProperty.id] = idx;
+      }
+    }
+    const allPropertiesPromise = Promise.all(propertyPromises);
+
+    // Import annotation values for properties
+    const newValueDonePromises: Promise<any>[] = [];
+    if (this.importValues && this.importProperties && this.importAnnotations) {
+      // Need annotations and properties to be sent before sending values
+      Promise.all([allAnnotationsPromise, allPropertiesPromise]).then(
+        ([oldIdToNewAnnotation, newProperties]) => {
+          for (const oldAnnotationId in this.values) {
+            const newAnnotation = oldIdToNewAnnotation.get(oldAnnotationId);
+            if (!newAnnotation) {
+              throw "Can't find the annotation having the values";
+            }
+            const oldAnnotationValues = this.values[oldAnnotationId];
+            const newAnnotationValues: IAnnotationPropertyValues[0] = {};
+            for (const oldPropertyId in oldAnnotationValues) {
+              const newProperty =
+                newProperties[propertyOldIdToIdx[oldPropertyId]];
+              const value = oldAnnotationValues[oldPropertyId];
+              newAnnotationValues[newProperty.id] = value;
+            }
+            const newValueDonePromise = this.store.girderRest.post(
+              `annotation_property_values?datasetId=${
+                this.store.dataset!.id
+              }&annotationId=${newAnnotation.id}`,
+              newAnnotationValues
+            );
+            newValueDonePromises.push(newValueDonePromise);
+          }
+        }
+      );
+    }
+    const allValuesDonePromise = Promise.all(newValueDonePromises);
+
+    this.isImporting = true;
+    Promise.all([
+      allAnnotationsPromise,
+      allPropertiesPromise,
+      allConnectionsPromise,
+      allValuesDonePromise
+    ])
+      .catch(() => {
+        // Don't remove annotations
+        annotationIdsToRemove.length = 0;
+        // Remove imported annotations if possible
+        allAnnotationsPromise
+          .then(oldIdToNewAnnotation => {
+            for (const { id } of oldIdToNewAnnotation.values()) {
+              annotationIdsToRemove.push(id);
+            }
+          })
+          .catch();
+      })
+      .then(() => {
+        if (annotationIdsToRemove.length > 0) {
+          return this.store.annotationsAPI.deleteMultipleAnnotations(
+            annotationIdsToRemove
+          );
+        }
+        return null;
+      })
+      .then(() => {
+        this.annotationStore.fetchAnnotations();
+        this.propertyStore.fetchProperties();
+        this.propertyStore.fetchPropertyValues();
+      })
+      .finally(() => {
+        this.reset();
+      });
+  }
+}
+</script>

--- a/src/components/ContrastHistogram.vue
+++ b/src/components/ContrastHistogram.vue
@@ -380,7 +380,10 @@ export default class ContrastHistogram extends Vue {
     }
     const bins = this.histData.hist;
     let maxValue = bins.reduce((acc, v) => Math.max(acc, v), 0);
-    const secondMax = bins.reduce((acc, v) => Math.max(acc, v !== maxValue ? v : 0), 0);
+    const secondMax = bins.reduce(
+      (acc, v) => Math.max(acc, v !== maxValue ? v : 0),
+      0
+    );
     maxValue = Math.min(maxValue, secondMax * 1.5);
     const scaleY = scaleLinear()
       .domain([0, maxValue])

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -316,7 +316,8 @@ export default class ImageViewer extends Vue {
       mapentry.annotationLayer = map.createLayer("annotation", {
         annotations: geojs.listAnnotations(),
         autoshareRenderer: false,
-        continuousCloseProximity: true
+        continuousCloseProximity: true,
+        showLabels: false
       });
       mapentry.workerPreviewLayer = map.createLayer("feature", {
         renderer: mllidx ? "canvas" : undefined,

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -271,6 +271,7 @@ import { Vue, Component, Prop, Watch } from "vue-property-decorator";
 import store from "@/store";
 import geojs from "geojs";
 import { formatDate } from "@/utils/date";
+import { downloadToClient } from "@/utils/download";
 
 interface ISnapshotItem {
   name: string;
@@ -448,10 +449,10 @@ export default class Snapshots extends Vue {
       e => encodeURIComponent(e[0]) + "=" + encodeURIComponent("" + e[1])
     );
     url += "?" + queryParts.join("&");
-    const link = document.createElement("a");
-    link.download = "screenshot." + (this.format === "png" ? "png" : "jpg");
-    link.href = url;
-    link.click();
+    downloadToClient({
+      href: url,
+      download: "screenshot." + (this.format === "png" ? "png" : "jpg")
+    });
   }
 
   setBoundingBox(left: number, top: number, right: number, bottom: number) {

--- a/src/store/PropertiesAPI.ts
+++ b/src/store/PropertiesAPI.ts
@@ -3,6 +3,7 @@ import {
   IAnnotationProperty,
   IWorkerInterface,
   IToolConfiguration,
+  IAnnotationPropertyValues,
   IWorkerImageList,
   IAnnotationPropertyConfiguration
 } from "./model";
@@ -53,10 +54,10 @@ export default class PropertiesAPI {
     );
   }
 
-  async getPropertyValues(datasetId: string) {
-    const annotationMapping: {
-      [annotationId: string]: { [propertyId: string]: number };
-    } = {};
+  async getPropertyValues(
+    datasetId: string
+  ): Promise<IAnnotationPropertyValues> {
+    const annotationMapping: IAnnotationPropertyValues = {};
 
     const pages = await fetchAllPages(
       this.client,

--- a/src/store/filters.ts
+++ b/src/store/filters.ts
@@ -232,6 +232,15 @@ export class Filters extends VuexModule {
     });
   }
 
+  get filteredAnnotationIdToIdx() {
+    const idToIdx: Map<string, number> = new Map();
+    const annotations = this.filteredAnnotations;
+    for (let i = 0; i < annotations.length; ++i) {
+      idToIdx.set(annotations[i].id, i);
+    }
+    return idToIdx;
+  }
+
   @Mutation
   public updatePropertyFilter(value: IPropertyAnnotationFilter) {
     this.propertyFilters = [

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -231,23 +231,30 @@ export interface IAnnotationLocation {
   Time: number;
 }
 
-export interface IAnnotation {
-  id: string;
+export interface IAnnotationBase {
   tags: string[];
-  name: string | null;
+  shape: AnnotationShape;
   channel: number;
   location: IAnnotationLocation;
-  shape: AnnotationShape;
   coordinates: IGeoJSPoint[];
   datasetId: string;
 }
 
-export interface IAnnotationConnection {
+export interface IAnnotation extends IAnnotationBase {
   id: string;
+  name: string | null;
+}
+
+export interface IAnnotationConnectionBase {
   label: string;
   tags: string[];
   parentId: string;
   childId: string;
+  datasetId: string;
+}
+
+export interface IAnnotationConnection extends IAnnotationConnectionBase {
+  id: string;
 }
 
 export interface IAnnotationFilter {
@@ -295,6 +302,19 @@ export interface IAnnotationPropertyConfiguration {
 
 export interface IAnnotationProperty extends IAnnotationPropertyConfiguration {
   id: string;
+}
+
+export interface IAnnotationPropertyValues {
+  [annotationId: string]: {
+    [propertyId: string]: number;
+  };
+}
+
+export interface ISerializedData {
+  annotations: IAnnotation[];
+  annotationConnections: IAnnotationConnection[];
+  annotationProperties: IAnnotationProperty[];
+  annotationPropertyValues: IAnnotationPropertyValues;
 }
 
 export interface IComputeJob {

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -11,6 +11,7 @@ import {
   IAnnotationProperty,
   IWorkerInterface,
   IToolConfiguration,
+  IAnnotationPropertyValues,
   IWorkerImageList,
   IAnnotationPropertyConfiguration,
   IAnnotation
@@ -33,9 +34,7 @@ export class Properties extends VuexModule {
 
   annotationListIds: string[] = [];
 
-  propertyValues: {
-    [annotationId: string]: { [propertyId: string]: number };
-  } = {};
+  propertyValues: IAnnotationPropertyValues = {};
 
   workerImageList: IWorkerImageList = {};
   workerInterfaces: { [image: string]: IWorkerInterface } = {};
@@ -94,9 +93,7 @@ export class Properties extends VuexModule {
   }
 
   @Mutation
-  updatePropertyValues(values: {
-    [annotationId: string]: { [propertyId: string]: number };
-  }) {
+  updatePropertyValues(values: IAnnotationPropertyValues) {
     // TODO(performance): merge instead
     this.propertyValues = values;
   }

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -12,7 +12,7 @@ import { logError } from "@/utils/log";
 
 // Which style an annotation should have, depending on its layer (color change)
 export function getAnnotationStyleFromLayer(
-  layer: IDisplayLayer | undefined,
+  layerColor: string | undefined,
   isHovered: boolean = false,
   isSelected: boolean = false
 ) {
@@ -27,9 +27,9 @@ export function getAnnotationStyleFromLayer(
     radius: 10
   };
 
-  if (layer) {
-    style.fillColor = layer.color;
-    style.strokeColor = layer.color;
+  if (layerColor) {
+    style.fillColor = layerColor;
+    style.strokeColor = layerColor;
   }
   if (isSelected) {
     style.strokeWidth = 5;

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,14 @@
+export function downloadToClient(params: { [attribute: string]: any }): void {
+  const element = document.createElement("a");
+
+  for (const [attribute, value] of Object.entries(params)) {
+    element.setAttribute(attribute, value);
+  }
+
+  element.style.display = "none";
+  document.body.appendChild(element);
+
+  element.click();
+
+  document.body.removeChild(element);
+}


### PR DESCRIPTION
The import / export buttons are currently in the annotation browser but can be moved in the future (but after PR #333 to avoid conflicts)

Fix some performance issues: rework annotation viewer, use Maps and Sets
Fix an untracked bug which made annotation connections between annotations of different datasets possible
Change style of annotations instead of removing and adding them
Add some endpoints for bulk POST and DELETE
Clean connections and property values orphans when deleting annotations
Add downloadToClient helper function

Annotation property values exported before/after PR #333 but computed with a worker after/before PR #333 can't be imported
This problem shouldn't be a problem for final users if the update of the workers is done at the same time as the update of the frontend
A workaround is to not export or import values and recompute them

Closes #255 
Closes #329 
Closes #285
Closes #355 
