### PR TITLE
Fix an issue debouncing histogram calls.

### DIFF
--- a/src/components/ValueSlider.vue
+++ b/src/components/ValueSlider.vue
@@ -62,7 +62,7 @@ export default class ValueSlider extends Vue {
 
   set slider(value: number) {
     const numberValue = typeof value === "number" ? value : parseInt(value);
-    if (numberValue == this.internalValue) {
+    if (numberValue === this.internalValue) {
       return;
     }
     this.internalValue = numberValue;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1001,6 +1001,7 @@ export class Main extends VuexModule {
         ) {
           const histogramObj = layer._histogram;
           const images = layer._histogram.nextImages;
+          histogramObj.nextImages = null;
           histogramObj.lock = true;
           histogramObj.promise = this.api.getLayerHistogram(images);
           histogramObj.promise.then(value => {
@@ -1011,7 +1012,6 @@ export class Main extends VuexModule {
           });
           histogramObj.promise.finally(() => {
             histogramObj.lastImages = images;
-            histogramObj.nextImages = null;
             histogramObj.lock = false;
             nextHistogram();
           });


### PR DESCRIPTION
If you switch frames quickly, multiple histogram calls are made to the server.  There was a bug that if there was a pending histogram call, the next histogram call might be skipped.

Fixes #356.