### PR TITLE
Undo redo

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/__init__.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/__init__.py
@@ -19,6 +19,7 @@ from .server.models.property import AnnotationProperty as PropertyModel
 from .server.models.workerInterfaces import WorkerInterfaceModel as InterfaceModel
 from .server.models.workerPreviews import WorkerPreviewModel as PreviewModel
 from .server.models.datasetView import DatasetView as DatasetViewModel
+from .server.models.history import History as HistoryModel
 
 from .server.api.annotation import Annotation
 from .server.api.connections import AnnotationConnection
@@ -27,6 +28,9 @@ from .server.api.property import AnnotationProperty
 from .server.api.workerInterfaces import WorkerInterfaces
 from .server.api.workerPreviews import WorkerPreviews
 from .server.api.datasetView import DatasetView
+from .server.api.history import History
+
+
 class UPennContrastAnnotationAPIPlugin(GirderPlugin):
     DISPLAY_NAME = 'UPennContrast Annotation Plugin'
     def load(self, info):
@@ -34,9 +38,10 @@ class UPennContrastAnnotationAPIPlugin(GirderPlugin):
         ModelImporter.registerModel('annotation_connection', ConnectionModel, 'upenncontrast_annotation')
         ModelImporter.registerModel('annotation_property_values', PropertyValuesModel, 'upenncontrast_annotation')
         ModelImporter.registerModel('annotation_property', PropertyModel, 'upenncontrast_annotation')
-        ModelImporter.registerModel('worker_interface', InterfaceModel, 'upenncontrast_worker_interface')
-        ModelImporter.registerModel('worker_preview', PreviewModel, 'upenncontrast_worker_preview')
-        ModelImporter.registerModel('dataset_view', DatasetViewModel, 'upenncontrast_dataset_view')
+        ModelImporter.registerModel('worker_interface', InterfaceModel, 'upenncontrast_annotation')
+        ModelImporter.registerModel('worker_preview', PreviewModel, 'upenncontrast_annotation')
+        ModelImporter.registerModel('dataset_view', DatasetViewModel, 'upenncontrast_annotation')
+        ModelImporter.registerModel('history', HistoryModel, 'upenncontrast_annotation')
 
         info['apiRoot'].upenn_annotation = Annotation()
         info['apiRoot'].annotation_connection = AnnotationConnection()
@@ -45,4 +50,5 @@ class UPennContrastAnnotationAPIPlugin(GirderPlugin):
         info['apiRoot'].worker_interface = WorkerInterfaces()
         info['apiRoot'].worker_preview = WorkerPreviews()
         info['apiRoot'].dataset_view = DatasetView()
+        info['apiRoot'].history = History()
         system.addSystemEndpoints(info['apiRoot'])

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -3,8 +3,34 @@ from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, loadmodel
 from girder.constants import AccessType
 from girder.exceptions import AccessException, RestException
-from ..helpers.proxiedModel import recordable
+from ..helpers.proxiedModel import recordable, cacheBodyJson
 from ..models.annotation import Annotation as AnnotationModel
+
+from bson.objectid import ObjectId
+
+
+# Helper functions to get dataset ID for recordable endpoints
+
+def getDatasetIdFromAnnotationInBody(self: 'Annotation', *args, **kwargs):
+    annotation = self.getBodyJson()
+    return annotation['datasetId']
+
+def getDatasetIdFromAnnotationListInBody(self: 'Annotation', *args, **kwargs):
+    annotations = self.getBodyJson()
+    return None if len(annotations) <= 0 else annotations[0]['datasetId']
+
+def getDatasetIdFromLoadedAnnotation(self: 'Annotation', *args, **kwargs):
+    annotation = kwargs['upenn_annotation']
+    return annotation['datasetId']
+
+def getDatasetIdFromAnnotationIdListInBody(self: 'Annotation', *args, **kwargs):
+    annotationStringIds = self.getBodyJson()
+    query = {
+      '_id': { '$in': [ObjectId(stringId) for stringId in annotationStringIds] },
+    }
+    cursor = self._annotationModel.findWithPermissions(query, user=self.getCurrentUser(), level=AccessType.READ, limit=1)
+    annotation = next(cursor, None)
+    return None if annotation is None else annotation['datasetId']
 
 
 class Annotation(Resource):
@@ -13,7 +39,7 @@ class Annotation(Resource):
         super().__init__()
         self.resourceName = 'upenn_annotation'
 
-        self._annotationModel = AnnotationModel()
+        self._annotationModel: AnnotationModel = AnnotationModel()
 
         self.route('DELETE', (':id',), self.delete)
         self.route('GET', (':id',), self.get)
@@ -31,18 +57,20 @@ class Annotation(Resource):
     # TODO(performance): use objectId whenever possible
     # TODO: error handling and documentation
 
+    @cacheBodyJson
     @access.user
     @describeRoute(Description("Create a new annotation").param('body', 'Annotation Object', paramType='body'))
-    @recordable('Create an annotation')
+    @recordable('Create an annotation', getDatasetIdFromAnnotationInBody)
     def create(self, params):
         currentUser = self.getCurrentUser()
         if not currentUser:
             raise AccessException('User not found', 'currentUser')
         return self._annotationModel.create(currentUser, self.getBodyJson())
 
+    @cacheBodyJson
     @access.user
     @describeRoute(Description("Create multiple new annotations").param('body', 'Annotation Object List', paramType='body'))
-    @recordable('Create multiple annotations')
+    @recordable('Create multiple annotations', getDatasetIdFromAnnotationListInBody)
     def createMultiple(self, params):
         currentUser = self.getCurrentUser()
         if not currentUser:
@@ -53,14 +81,15 @@ class Annotation(Resource):
                    .errorResponse('Write access was denied for the annotation.', 403))
     @access.user
     @loadmodel(model='upenn_annotation', plugin='upenncontrast_annotation', level=AccessType.WRITE)
-    @recordable('Delete an annotation')
+    @recordable('Delete an annotation', getDatasetIdFromLoadedAnnotation)
     def delete(self, upenn_annotation, params):
         self._annotationModel.delete(upenn_annotation)
 
+    @cacheBodyJson
     @access.user
     @describeRoute(Description("Delete all annotations in the id list")
                    .param('body', 'A list of all annotation ids to delete.', paramType='body'))
-    @recordable('Delete multiple annotations')
+    @recordable('Delete multiple annotations', getDatasetIdFromAnnotationIdListInBody)
     def deleteMultiple(self, params):
         stringIds = [stringId for stringId in self.getBodyJson()]
         self._annotationModel.deleteMultiple(stringIds)
@@ -74,7 +103,7 @@ class Annotation(Resource):
                    .errorResponse("Validation Error: JSON doesn't follow schema."))
     @access.user
     @loadmodel(model='upenn_annotation', plugin='upenncontrast_annotation', level=AccessType.WRITE)
-    @recordable('Update an annotation')
+    @recordable('Update an annotation', getDatasetIdFromLoadedAnnotation)
     def update(self, upenn_annotation, params):
         upenn_annotation.update(self.getBodyJson())
         self._annotationModel.update(upenn_annotation)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -1,9 +1,10 @@
 from girder.api import access
-from girder.api.describe import Description, autoDescribeRoute, describeRoute
-from girder.constants import AccessType
+from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, loadmodel
+from girder.constants import AccessType
+from girder.exceptions import AccessException, RestException
+from ..helpers.proxiedModel import recordable
 from ..models.annotation import Annotation as AnnotationModel
-from girder.exceptions import AccessException, RestException, ValidationException
 
 
 class Annotation(Resource):
@@ -32,6 +33,7 @@ class Annotation(Resource):
 
     @access.user
     @describeRoute(Description("Create a new annotation").param('body', 'Annotation Object', paramType='body'))
+    @recordable('Create an annotation')
     def create(self, params):
         currentUser = self.getCurrentUser()
         if not currentUser:
@@ -40,6 +42,7 @@ class Annotation(Resource):
 
     @access.user
     @describeRoute(Description("Create multiple new annotations").param('body', 'Annotation Object List', paramType='body'))
+    @recordable('Create multiple annotations')
     def createMultiple(self, params):
         currentUser = self.getCurrentUser()
         if not currentUser:
@@ -50,12 +53,14 @@ class Annotation(Resource):
                    .errorResponse('Write access was denied for the annotation.', 403))
     @access.user
     @loadmodel(model='upenn_annotation', plugin='upenncontrast_annotation', level=AccessType.WRITE)
+    @recordable('Delete an annotation')
     def delete(self, upenn_annotation, params):
         self._annotationModel.delete(upenn_annotation)
 
     @access.user
     @describeRoute(Description("Delete all annotations in the id list")
                    .param('body', 'A list of all annotation ids to delete.', paramType='body'))
+    @recordable('Delete multiple annotations')
     def deleteMultiple(self, params):
         stringIds = [stringId for stringId in self.getBodyJson()]
         self._annotationModel.deleteMultiple(stringIds)
@@ -69,6 +74,7 @@ class Annotation(Resource):
                    .errorResponse("Validation Error: JSON doesn't follow schema."))
     @access.user
     @loadmodel(model='upenn_annotation', plugin='upenncontrast_annotation', level=AccessType.WRITE)
+    @recordable('Update an annotation')
     def update(self, upenn_annotation, params):
         upenn_annotation.update(self.getBodyJson())
         self._annotationModel.update(upenn_annotation)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
@@ -1,9 +1,10 @@
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute, describeRoute
-from girder.constants import AccessType
 from girder.api.rest import Resource, loadmodel
+from girder.constants import AccessType
+from girder.exceptions import AccessException
+from ..helpers.proxiedModel import recordable
 from ..models.connections import AnnotationConnection as ConnectionModel
-from girder.exceptions import AccessException, RestException, ValidationException
 
 
 class AnnotationConnection(Resource):
@@ -30,6 +31,7 @@ class AnnotationConnection(Resource):
 
     @access.user
     @describeRoute(Description("Create a new connection").param('body', 'Connection Object', paramType='body'))
+    @recordable('Create a connection')
     def create(self, params):
         currentUser = self.getCurrentUser()
         if not currentUser:
@@ -38,6 +40,7 @@ class AnnotationConnection(Resource):
 
     @access.user
     @describeRoute(Description("Create multiple new connections").param('body', 'Connection Object List', paramType='body'))
+    @recordable('Create multiple connections')
     def multipleCreate(self, params):
         currentUser = self.getCurrentUser()
         if not currentUser:
@@ -48,12 +51,14 @@ class AnnotationConnection(Resource):
                    .errorResponse('Write access was denied for the connection.', 403))
     @access.user
     @loadmodel(model='annotation_connection', plugin='upenncontrast_annotation', level=AccessType.WRITE)
+    @recordable('Delete a connection')
     def delete(self, annotation_connection, params):
         self._connectionModel.remove(annotation_connection)
     
     @access.user
     @describeRoute(Description("Delete all annotation connections in the id list")
                    .param('body', 'A list of all annotation connection ids to delete.', paramType='body'))
+    @recordable('Delete multiple connections')
     def deleteMultiple(self, params):
         stringIds = [stringId for stringId in self.getBodyJson()]
         self._connectionModel.deleteMultiple(stringIds)
@@ -67,6 +72,7 @@ class AnnotationConnection(Resource):
                    .errorResponse("Validation Error: JSON doesn't follow schema."))
     @access.user
     @loadmodel(model='annotation_connection', plugin='upenncontrast_annotation', level=AccessType.WRITE)
+    @recordable('Update a connection')
     def update(self, connection, params):
         connection.update(self.getBodyJson())
         self._connectionModel.update(connection)
@@ -111,6 +117,7 @@ class AnnotationConnection(Resource):
 
     @access.user
     @describeRoute(Description("Create connections between annotations").param('body', 'Connection Object', paramType='body'))
+    @recordable('Create connections with nearest')
     def connectToNearest(self, params):
         currentUser = self.getCurrentUser()
         if not currentUser:

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
@@ -24,7 +24,7 @@ class DatasetView(Resource):
     @access.user
     @describeRoute(Description('Get a dataset view by its id.')
         .param('id', 'The dataset view\'s id', paramType='path'))
-    @loadmodel(model='dataset_view', plugin='upenncontrast_dataset_view', level=AccessType.READ)
+    @loadmodel(model='dataset_view', plugin='upenncontrast_annotation', level=AccessType.READ)
     def get(self, dataset_view, params):
         return dataset_view
     
@@ -50,7 +50,7 @@ class DatasetView(Resource):
     @describeRoute(Description('Delete an existing dataset view.').param('id', 'The dataset view\'s Id', paramType='path').errorResponse('ID was invalid.')
         .errorResponse('Write access was denied for the dataset view.', 403))
     @access.user
-    @loadmodel(model='dataset_view', plugin='upenncontrast_dataset_view', level=AccessType.WRITE)
+    @loadmodel(model='dataset_view', plugin='upenncontrast_annotation', level=AccessType.WRITE)
     def delete(self, dataset_view, params):
         self._datasetViewModel.delete(dataset_view)
 
@@ -62,7 +62,7 @@ class DatasetView(Resource):
     .errorResponse('Invalid JSON passed in request body.')
     .errorResponse('Validation Error: JSON doesn\'t follow schema.'))
     @access.user
-    @loadmodel(model='dataset_view', plugin='upenncontrast_dataset_view', level=AccessType.WRITE)
+    @loadmodel(model='dataset_view', plugin='upenncontrast_annotation', level=AccessType.WRITE)
     def update(self, dataset_view, params):
         self._datasetViewModel.update(dataset_view, self.getBodyJson())
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/history.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/history.py
@@ -1,0 +1,42 @@
+from girder.api import access
+from girder.api.describe import Description, describeRoute
+from girder.api.rest import Resource
+from girder.constants import SortDir, AccessType
+from girder.exceptions import AccessException
+from ..models.history import History as HistoryModel
+
+class History(Resource):
+
+    def __init__(self):
+        super().__init__()
+        self.resourceName = 'history'
+
+        self._historyModel = HistoryModel()
+
+        self.route('GET', (), self.find)
+        self.route('PUT', ('undo',), self.undo)
+        self.route('PUT', ('redo',), self.redo)
+
+    @access.user
+    @describeRoute(Description("Get last history actions for the user, from the most recent to the oldest"))
+    def find(self, params):
+        user = self.getCurrentUser()
+        if user is None:
+            raise AccessException('You must be logged in.')
+        return self._historyModel.getLastEntries(user)
+
+    @access.user
+    @describeRoute(Description("Undo the last history entry which hasn't been undone"))
+    def undo(self, params):
+        user = self.getCurrentUser()
+        if user is None:
+            raise AccessException('You must be logged in.')
+        return self._historyModel.undo(user)
+
+    @access.user
+    @describeRoute(Description("Redo the last history entry which has been undone"))
+    def redo(self, params):
+        user = self.getCurrentUser()
+        if user is None:
+            raise AccessException('You must be logged in.')
+        self._historyModel.redo(user)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/history.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/history.py
@@ -1,9 +1,9 @@
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource
-from girder.constants import SortDir, AccessType
-from girder.exceptions import AccessException
+from girder.exceptions import AccessException, RestException
 from ..models.history import History as HistoryModel
+from bson.objectid import ObjectId
 
 class History(Resource):
 
@@ -11,32 +11,44 @@ class History(Resource):
         super().__init__()
         self.resourceName = 'history'
 
-        self._historyModel = HistoryModel()
+        self._historyModel: HistoryModel = HistoryModel()
 
         self.route('GET', (), self.find)
         self.route('PUT', ('undo',), self.undo)
         self.route('PUT', ('redo',), self.redo)
 
     @access.user
-    @describeRoute(Description("Get last history actions for the user, from the most recent to the oldest"))
+    @describeRoute(Description("Get last history actions for the user, from the most recent to the oldest")
+                   .param('datasetId', 'The dataset in which are the history entries', required=True))
     def find(self, params):
         user = self.getCurrentUser()
         if user is None:
             raise AccessException('You must be logged in.')
-        return self._historyModel.getLastEntries(user)
+        if 'datasetId' not in params:
+            raise RestException(code=400, message='Dataset ID is missing')
+        datasetId = ObjectId(params['datasetId'])
+        return self._historyModel.getLastEntries(user, datasetId)
 
     @access.user
-    @describeRoute(Description("Undo the last history entry which hasn't been undone"))
+    @describeRoute(Description("Undo the last history entry which hasn't been undone")
+                   .param('datasetId', 'The dataset in which undo should be done', required=True))
     def undo(self, params):
         user = self.getCurrentUser()
         if user is None:
             raise AccessException('You must be logged in.')
-        return self._historyModel.undo(user)
+        if 'datasetId' not in params:
+            raise RestException(code=400, message='Dataset ID is missing')
+        datasetId = ObjectId(params['datasetId'])
+        return self._historyModel.undo(user, datasetId)
 
     @access.user
-    @describeRoute(Description("Redo the last history entry which has been undone"))
+    @describeRoute(Description("Redo the last history entry which has been undone")
+                   .param('datasetId', 'The dataset in which redo should be done', required=True))
     def redo(self, params):
         user = self.getCurrentUser()
         if user is None:
             raise AccessException('You must be logged in.')
-        self._historyModel.redo(user)
+        if 'datasetId' not in params:
+            raise RestException(code=400, message='Dataset ID is missing')
+        datasetId = ObjectId(params['datasetId'])
+        self._historyModel.redo(user, datasetId)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/propertyValues.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/propertyValues.py
@@ -1,17 +1,15 @@
 from girder.api import access
-from girder.api.describe import Description, autoDescribeRoute, describeRoute
+from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType
-from girder.api.rest import Resource, loadmodel
-from ..models.annotation import Annotation as AnnotationModel
+from girder.api.rest import Resource
 from ..models.propertyValues import AnnotationPropertyValues as PropertyValuesModel
-from girder.exceptions import AccessException, RestException, ValidationException
+from girder.exceptions import AccessException, RestException
 
 
 class PropertyValues(Resource):
     def __init__(self):
         super().__init__()
         self.resourceName = 'annotation_property_values'
-        self._annotationModel = AnnotationModel()
         self._annotationPropertyValuesModel = PropertyValuesModel()
 
         self.route('DELETE', (), self.delete)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/proxiedModel.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/proxiedModel.py
@@ -97,7 +97,6 @@ class recordable:
 
         return wrapped_fun
 
-@dataclass
 class ModelRecord:
     """
     A record of changes made to the database

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/proxiedModel.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/proxiedModel.py
@@ -1,0 +1,135 @@
+from girder import events
+from girder.api import rest
+from girder.exceptions import AccessException
+from girder.models.model_base import AccessControlledModel, Model
+
+from dataclasses import dataclass
+from ..models.history import History as HistoryModel
+
+
+class recordable:
+    """
+    A decorator which makes a function able to record the write operations on the database
+    """
+    def __init__(self, actionName):
+        self.historyModel: HistoryModel = HistoryModel()
+        self.actionName = actionName
+
+    def __call__(self, fun):
+        def wrapped_fun(*args, **kwargs):
+            actionDate = HistoryModel.now()
+
+            # Wrap original endpoint between a start and a stop recording
+            events.trigger('proxiedModel.startRecording')
+            val = fun(*args, **kwargs)
+            record = events.trigger('proxiedModel.stopRecording', {}).info
+
+            # Create a new history document
+            user = rest.getCurrentUser()
+            if user is None:
+                raise AccessException('You must be logged in.')
+            document = {
+                'actionName': self.actionName,
+                'record': record,
+                'actionDate': actionDate,
+                'userId': user['_id'], # type: ignore
+                'isUndone': False,
+            }
+            self.historyModel.create(user, document)
+
+            return val
+
+        return wrapped_fun
+
+@dataclass
+class ModelRecord:
+    """
+    A record of changes made to the database
+    "changes" associates a string id (not an ObjectId) with a dict:
+    { before: document or None, after: document or None }
+    """
+    def __init__(self):
+        self.changes = {}
+
+    def changeDocument(self, before, after):
+        doc_with_id = before if before is not None else after if after is not None else None
+        if doc_with_id is None:
+            return
+        string_id = str(doc_with_id['_id'])
+        old_change = self.changes.get(string_id, None)
+        if old_change:
+            # old_change[after] == before
+            old_change[after] = after
+        else:
+            self.changes[string_id] = { 'before': before, 'after': after }
+
+
+class ProxiedAccessControlledModel(AccessControlledModel):
+    """
+    Enable recording of changes made to the database
+    """
+    def __init__(self):
+        events.bind('proxiedModel.startRecording', 'upenn.proxiedModel.' + self.__class__.__name__ + '.startRecording', self.startRecordingEvent)
+        events.bind('proxiedModel.stopRecording', 'upenn.proxiedModel.' + self.__class__.__name__ + '.stopRecording', self.stopRecordingEvent)
+        super().__init__()
+        self.is_recording = False
+        self.record = ModelRecord()
+
+    def startRecordingEvent(self, event):
+        self.startRecording()
+        # List all the models recording changes
+        if event.info is None:
+            event.info = []
+        event.info.append(self.name)
+
+    def stopRecordingEvent(self, event):
+        record = self.stopRecording()
+        # Map a model name with the changes
+        if event.info is None:
+            event.info = {}
+        event.info[self.name] = record.changes
+
+    def startRecording(self):
+        self.is_recording = True
+        self.record = ModelRecord()
+
+    def stopRecording(self):
+        self.is_recording = False
+        record = self.record
+        self.record = ModelRecord()
+        return record
+
+    def removeWithQuery(self, query):
+        if self.is_recording:
+            docs_before = self.find(query)
+            for before in docs_before:
+                self.record.changeDocument(before, None)
+        return super().removeWithQuery(query)
+
+    def remove(self, document, **kwargs):
+        if self.is_recording:
+            before = self.findOne({ '_id': document['_id'] })
+            self.record.changeDocument(before, None)
+        return super().remove(document, **kwargs)
+
+    def update(self, query, update, multi=True):
+        if self.is_recording:
+            docs_before = self.find(query)
+            for before in docs_before:
+                self.record.changeDocument(before, None)
+            val = super().update(query, update, multi)
+            docs_after = self.find(query)
+            for after in docs_after:
+                self.record.changeDocument(None, after)
+            return val
+        return super().update(query, update, multi)
+
+    def save(self, document, validate=True, triggerEvents=True):
+        if self.is_recording:
+            if '_id' in document:
+                before = self.findOne({ '_id': document['_id'] })
+                self.record.changeDocument(before, None)
+            after = super().save(document, validate, triggerEvents)
+            self.record.changeDocument(None, after)
+            return after
+        return super().save(document, validate, triggerEvents)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
@@ -1,9 +1,9 @@
 from ..helpers.tasks import runJobRequest
-from girder.models.model_base import AccessControlledModel
-from girder.exceptions import AccessException, ValidationException, RestException
+from ..helpers.proxiedModel import ProxiedAccessControlledModel
+from girder.exceptions import ValidationException, RestException
 from girder.constants import AccessType
 from .propertyValues import AnnotationPropertyValues as PropertiesModel
-from girder import events, logprint, logger, auditLogger
+from girder import events
 
 from bson.objectid import ObjectId
 
@@ -71,7 +71,7 @@ class AnnotationSchema:
         'required': ['coordinates', 'tags', 'channel', 'location', 'shape', 'datasetId']
     }
 
-class Annotation(AccessControlledModel):
+class Annotation(ProxiedAccessControlledModel):
   '''
     Defines a model for storing and handling UPennContrast annotations in the database.
   '''

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/connections.py
@@ -1,5 +1,5 @@
-from girder.models.model_base import AccessControlledModel
-from girder.exceptions import AccessException, ValidationException
+from ..helpers.proxiedModel import ProxiedAccessControlledModel
+from girder.exceptions import ValidationException
 from girder.constants import AccessType
 from girder import events
 
@@ -35,7 +35,7 @@ class ConnectionSchema:
         'required': ['parentId', 'childId', 'datasetId', 'tags']
     }
 
-class AnnotationConnection(AccessControlledModel):
+class AnnotationConnection(ProxiedAccessControlledModel):
   # TODO: write lock
   # TODO(performance): indexing
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/datasetView.py
@@ -1,6 +1,6 @@
 from girder.constants import AccessType
 from girder.exceptions import ValidationException
-from girder.models.model_base import AccessControlledModel
+from ..helpers.proxiedModel import ProxiedAccessControlledModel
 
 import jsonschema
 
@@ -22,7 +22,7 @@ class DatasetViewSchema:
     }
     datasetViewSchema = {
         '$schema': 'http://json-schema.org/schema#',
-        'id': '/girder/plugins/upenncontrast_annotation/models/annotation',
+        'id': '/girder/plugins/upenncontrast_annotation/models/datasetView',
         'type': 'object',
         'properties': {
             'datasetId': {
@@ -40,7 +40,7 @@ class DatasetViewSchema:
         'required': ['datasetId', 'configurationId', 'layerContrasts']
     }
 
-class DatasetView(AccessControlledModel):
+class DatasetView(ProxiedAccessControlledModel):
     validator = jsonschema.Draft4Validator(
         DatasetViewSchema.datasetViewSchema
     )

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/history.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/history.py
@@ -1,0 +1,160 @@
+from girder.constants import SortDir, AccessType
+from girder.exceptions import ValidationException
+from girder.models.model_base import AccessControlledModel
+from girder.utility.model_importer import ModelImporter
+
+from bson.objectid import ObjectId
+import datetime
+import jsonschema
+
+class HistorySchema:
+    # Example of recordSchema (recording an addition and a deletion of annotation):
+    # {
+    #     "annotations": {
+    #         "63d7fccbbb2c4fdb6eb1b0e8": { "before": None, "after": { "shape": "point", "channel": 0, ... } },
+    #         "63d7fdf7bb2c4fdb6eb1b0f4": { "before": { "shape": "polygon", "channel": 1, ... }, "after": None },
+    #     },
+    # }
+    recordSchema = {
+        # Record per model, keys are model names
+        'type': 'object',
+        'additionalProperties': {
+            # Changes per document, keys are stringified document ids (not ObjectIds)
+            'type': 'object',
+            'additionalProperties': {
+                'type': 'object',
+                'properties': {
+                    # Document before action, can be None, keys are document ids
+                    'before': {
+                        'type': ['object', 'null'],
+                    },
+                    # Document after action, can be None, keys are document ids
+                    'after': {
+                        'type': ['object', 'null'],
+                    },
+                },
+                'required': ['before', 'after'],
+            },
+        },
+    }
+
+    historySchema = {
+        '$schema': 'http://json-schema.org/schema#',
+        'id': '/girder/plugins/upenncontrast_annotation/models/history',
+        'type': 'object',
+        'properties': {
+            'actionName': {
+                'type': 'string',
+            },
+            'record': recordSchema,
+            # https://pymongo.readthedocs.io/en/stable/examples/datetimes.html
+            'actionDate': {
+                # Special type defined in a custom validator
+                'type': 'datetime',
+            },
+            'userId': {
+                # Special type defined in a custom validator
+                'type': 'objectId',
+            },
+            'isUndone': {
+                'type': 'boolean',
+            },
+        },
+        'required': ['actionName', 'record', 'actionDate', 'userId', 'isUndone']
+    }
+
+class History(AccessControlledModel):
+    '''
+    Register actions on some endpoints using the ProxiedAccessControlledModel
+    This class itself doesn't inherit the ProxiedAccessControlledModel
+    '''
+
+    BaseValidator = jsonschema.Draft4Validator
+
+    # Build a new type checker
+    # https://python-jsonschema.readthedocs.io/en/latest/validate/#type-checking
+    def is_datetime(checker, inst):
+        return isinstance(inst, datetime.datetime)
+    def is_objectId(checker, inst):
+        return isinstance(inst, ObjectId) and ObjectId.is_valid(inst)
+    date_check = BaseValidator.TYPE_CHECKER.redefine('datetime', is_datetime).redefine('objectId', is_objectId)
+
+    # Build a validator with the new type checker
+    # https://python-jsonschema.readthedocs.io/en/latest/creating/
+    CustomDraft4Validator = jsonschema.validators.extend(BaseValidator, type_checker=date_check)
+    validator = CustomDraft4Validator(HistorySchema.historySchema)
+
+    @staticmethod
+    def now():
+        return datetime.datetime.now(tz=datetime.timezone.utc)
+
+    def initialize(self):
+        self.name = "history"
+
+    def validate(self, document):
+        try:
+            self.validator.validate(document)
+        except jsonschema.ValidationError as exp:
+            print('Validation of an history document failed')
+            raise ValidationException(exp)
+        return document
+
+    def getLastEntries(self, user):
+        """
+        Get the history entries for this user, sorted by descending actionDate
+        Only return some fields from the model, as the record can be heavy and the userId is useless
+        """
+        query = { 'userId': user['_id'] }
+        sort = [('actionDate', SortDir.DESCENDING)]
+        fields = { '_id': 0, 'actionName': 1, 'actionDate': 1, 'isUndone': 1 }
+        return self.findWithPermissions(query, sort=sort, fields=fields, user=user)
+
+    def undo(self, user):
+        self.undoOrRedo(user, True)
+
+    def redo(self, user):
+        self.undoOrRedo(user, False)
+
+    def undoOrRedo(self, user, undo: bool):
+        # Get the most recent action which has (not) been undone
+        query = { 'userId': user['_id'], 'isUndone': not undo }
+        sort = [('actionDate', SortDir.DESCENDING if undo else SortDir.ASCENDING)]
+        history_entry = next(self.findWithPermissions(query, sort=sort, user=user, level=AccessType.WRITE, limit=1), None)
+        if history_entry is None:
+            return
+
+        # Undo or redo the action
+        change_key = 'before' if undo else 'after'
+        record_per_model = history_entry['record']
+        for model_name in record_per_model:
+            model: AccessControlledModel = ModelImporter.model(model_name, 'upenncontrast_annotation')
+            record_per_document = record_per_model[model_name]
+            for string_document_id in record_per_document:
+                change = record_per_document[string_document_id]
+                replacement = change[change_key]
+                if replacement is None:
+                    model.collection.delete_one({ '_id': ObjectId(string_document_id) })
+                else:
+                    model.collection.replace_one({ '_id': ObjectId(string_document_id) }, replacement, upsert=True)
+
+        # Update the entry
+        history_entry['isUndone'] = undo
+        return self.save(history_entry)
+
+    def create(self, creator, entry):
+        # Remove history entries older than 1 hour
+        limit_date = History.now() - datetime.timedelta(hours=1)
+        self.removeWithQuery({ 'actionDate': { '$lt': limit_date } })
+
+        # Remove history entries that have been undone
+        self.removeWithQuery({ 'userId': creator['_id'], 'isUndone': True })
+
+        # Cap the number of entries per user
+        limit_cap = 10
+        docs_to_remove = self.find({ 'userId': creator['_id'] }, sort=[('actionDate', SortDir.DESCENDING)], offset=limit_cap-1, fields={ '_id': 1 })
+        ids_to_remove = [doc['_id'] for doc in docs_to_remove]
+        if len(ids_to_remove) > 0:
+            self.removeWithQuery({ '_id': { '$in': ids_to_remove } })
+
+        self.setUserAccess(entry, user=creator, level=AccessType.ADMIN, save=False)
+        return self.save(entry)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/property.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/property.py
@@ -1,5 +1,5 @@
-from girder.models.model_base import AccessControlledModel
-from girder.exceptions import AccessException, ValidationException, RestException
+from ..helpers.proxiedModel import ProxiedAccessControlledModel
+from girder.exceptions import ValidationException, RestException
 from girder.constants import AccessType
 from ..helpers.tasks import runJobRequest
 
@@ -10,7 +10,7 @@ import jsonschema
 class PropertySchema:
     propertySchema = {
         '$schema': 'http://json-schema.org/schema#',
-        'id': '/girder/plugins/upenncontrast_annotation/models/annotation',
+        'id': '/girder/plugins/upenncontrast_annotation/models/property',
         'type': 'object',
         'properties': {
             'name': {
@@ -44,7 +44,7 @@ class PropertySchema:
     }
 
 
-class AnnotationProperty(AccessControlledModel):
+class AnnotationProperty(ProxiedAccessControlledModel):
     # TODO: write lock
     # TODO: delete hooks: remove all computed values if the property is deleted ? (big operation)
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/propertyValues.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/propertyValues.py
@@ -1,16 +1,14 @@
-from girder.models.model_base import AccessControlledModel
-from girder.exceptions import AccessException, ValidationException
-from girder.constants import AccessType
+from ..helpers.proxiedModel import ProxiedAccessControlledModel
+from girder.exceptions import ValidationException
 from girder import events
 
-from bson.objectid import ObjectId
 import jsonschema
 
 
 class PropertySchema:
     annotationPropertySchema = {
         '$schema': 'http://json-schema.org/schema#',
-        'id': '/girder/plugins/upenncontrast_annotation/models/annotation',
+        'id': '/girder/plugins/upenncontrast_annotation/models/propertyValues',
         'type': 'object',
         'properties': {
             'annotationId': {
@@ -28,7 +26,7 @@ class PropertySchema:
     }
 
 
-class AnnotationPropertyValues(AccessControlledModel):
+class AnnotationPropertyValues(ProxiedAccessControlledModel):
     validator = jsonschema.Draft4Validator(
         PropertySchema.annotationPropertySchema
     )

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/propertyValues.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/propertyValues.py
@@ -71,7 +71,7 @@ class AnnotationPropertyValues(ProxiedAccessControlledModel):
 
     def delete(self, propertyId, datasetId):
         # Could use self.collection.updateMany but girder doesn't expose this method
-        for document in self.find({'datasetId': datasetId}):
+        for document in self.find({'datasetId': datasetId, '.'.join(['values', propertyId]): { '$exists': True }}):
             document['values'].pop(propertyId, None)
             if len(document['values']) == 0:
                 self.remove(document)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerInterfaces.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerInterfaces.py
@@ -1,4 +1,4 @@
-from girder.models.model_base import AccessControlledModel
+from ..helpers.proxiedModel import ProxiedAccessControlledModel
 from girder.exceptions import ValidationException
 from girder.constants import AccessType
 from ..helpers.tasks import runJobRequest
@@ -9,7 +9,7 @@ import jsonschema
 class InterfaceSchema:
     interfaceSchema = {
         '$schema': 'http://json-schema.org/schema#',
-        'id': '/girder/plugins/upenncontrast_annotation/models/annotation',
+        'id': '/girder/plugins/upenncontrast_annotation/models/workerInterfaces',
         'type': 'object',
         'properties': {
             'name': {
@@ -34,7 +34,7 @@ class InterfaceSchema:
     }
 
 
-class WorkerInterfaceModel(AccessControlledModel):
+class WorkerInterfaceModel(ProxiedAccessControlledModel):
 
     validator = jsonschema.Draft4Validator(
         InterfaceSchema.interfaceSchema

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerPreviews.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerPreviews.py
@@ -1,9 +1,8 @@
-from girder.models.model_base import AccessControlledModel
-from girder.exceptions import AccessException, ValidationException, RestException
+from ..helpers.proxiedModel import ProxiedAccessControlledModel
+from girder.exceptions import ValidationException, RestException
 from girder.constants import AccessType
 from ..helpers.tasks import runJobRequest
 
-from bson.objectid import ObjectId
 import jsonschema
 
 
@@ -13,7 +12,7 @@ from girder.models.folder import Folder
 class PreviewSchema:
     previewSchema = {
         '$schema': 'http://json-schema.org/schema#',
-        'id': '/girder/plugins/upenncontrast_annotation/models/annotation',
+        'id': '/girder/plugins/upenncontrast_annotation/models/workerPreviews',
         'type': 'object',
         'properties': {
             'name': {
@@ -38,7 +37,7 @@ class PreviewSchema:
     }
 
 
-class WorkerPreviewModel(AccessControlledModel):
+class WorkerPreviewModel(ProxiedAccessControlledModel):
 
     validator = jsonschema.Draft4Validator(
         PreviewSchema.previewSchema

--- a/src/components/AnnotationBrowser/AnnotationActions.vue
+++ b/src/components/AnnotationBrowser/AnnotationActions.vue
@@ -119,11 +119,7 @@ export default class AnnotationActions extends Vue {
   async do(undo: boolean) {
     try {
       this.isDoing = true;
-      if (undo) {
-        await this.store.api.undo();
-      } else {
-        await this.store.api.redo();
-      }
+      await this.store.do(undo);
       await this.annotationStore.fetchAnnotations();
     } finally {
       this.isDoing = false;

--- a/src/components/AnnotationBrowser/AnnotationActions.vue
+++ b/src/components/AnnotationBrowser/AnnotationActions.vue
@@ -120,7 +120,6 @@ export default class AnnotationActions extends Vue {
     try {
       this.isDoing = true;
       await this.store.do(undo);
-      await this.annotationStore.fetchAnnotations();
     } finally {
       this.isDoing = false;
     }

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -168,6 +168,18 @@ export default class ImageViewer extends Vue {
       handler: () => {
         annotationStore.deleteSelectedAnnotations();
       }
+    },
+    {
+      bind: "mod+z",
+      handler: () => {
+        this.store.do(true);
+      }
+    },
+    {
+      bind: "mod+shift+z",
+      handler: () => {
+        this.store.do(false);
+      }
     }
   ];
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ Vue.use(VueAsyncComputed);
 Vue.use(vMousetrap);
 
 main.initialize();
+main.setupWatchers();
 
 new Vue({
   provide: {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -17,6 +17,7 @@ import {
   IDatasetViewBase,
   IDisplayLayer,
   IFrameInfo,
+  IHistoryEntry,
   IImage,
   IPixel,
   newLayer
@@ -108,11 +109,28 @@ export default class GirderAPI {
     });
   }
 
-  async generateTiles(itemId: string) {
+  undo() {
+    return this.client.put("history/undo");
+  }
+
+  redo() {
+    return this.client.put("history/redo");
+  }
+
+  async getHistoryEntries(): Promise<IHistoryEntry[]> {
+    try {
+      const response = await this.client.get("history");
+      return response.data.map(toHistoryEntry);
+    } catch {
+      return [];
+    }
+  }
+
+  generateTiles(itemId: string) {
     return this.client.post(`item/${itemId}/tiles`);
   }
 
-  async removeLargeImageForItem(item: IGirderItem) {
+  removeLargeImageForItem(item: IGirderItem) {
     return this.client.delete(`item/${item._id}/tiles`);
   }
 
@@ -608,6 +626,14 @@ function asDatasetView(data: AxiosResponse["data"]): IDatasetView {
     datasetId: data.datasetId,
     layerContrasts: data.layerContrasts,
     lastViewed: data.lastViewed
+  };
+}
+
+function toHistoryEntry(data: any): IHistoryEntry {
+  return {
+    actionName: data.actionName,
+    isUndone: data.isUndone,
+    actionDate: new Date(data.actionDate)
   };
 }
 

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -109,17 +109,22 @@ export default class GirderAPI {
     });
   }
 
-  undo() {
-    return this.client.put("history/undo");
+  undo(datasetId: string) {
+    return this.client.put("history/undo", undefined, {
+      params: { datasetId }
+    });
   }
 
-  redo() {
-    return this.client.put("history/redo");
+  redo(datasetId: string) {
+    return this.client.put("history/redo", undefined, {
+      params: { datasetId }
+    });
   }
 
-  async getHistoryEntries(): Promise<IHistoryEntry[]> {
+  async getHistoryEntries(datasetId: string): Promise<IHistoryEntry[]> {
     try {
-      const response = await this.client.get("history");
+      const params = { datasetId };
+      const response = await this.client.get("history", { params });
       return response.data.map(toHistoryEntry);
     } catch {
       return [];

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -389,7 +389,7 @@ export class Annotations extends VuexModule {
           this.annotationsAPI.getAnnotationsForDatasetId(main.dataset.id),
           this.annotationsAPI.getConnectionsForDatasetId(main.dataset.id)
         ];
-      Promise.all(promises).then(
+      await Promise.all(promises).then(
         ([annotations, connections]: [
           IAnnotation[],
           IAnnotationConnection[]

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -731,8 +731,31 @@ export class Main extends VuexModule {
   @Action
   @Debounce(100, { leading: false, trailing: true })
   async fetchHistory() {
-    const history = await this.api.getHistoryEntries();
-    this.setHistory(history);
+    const datasetId = this.dataset?.id;
+    if (datasetId !== undefined) {
+      const history = await this.api.getHistoryEntries(datasetId);
+      this.setHistory(history);
+    } else {
+      this.setHistory([]);
+    }
+  }
+
+  @Action
+  async do(undo: boolean) {
+    const datasetId = this.dataset?.id;
+    if (datasetId !== undefined) {
+      try {
+        sync.setSaving(true);
+        if (undo) {
+          await this.api.undo(datasetId);
+        } else {
+          await this.api.redo(datasetId);
+        }
+        sync.setSaving(false);
+      } catch (error) {
+        sync.setSaving(error);
+      }
+    }
   }
 
   @Action

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -751,6 +751,7 @@ export class Main extends VuexModule {
         } else {
           await this.api.redo(datasetId);
         }
+        this.context.dispatch("fetchAnnotations");
         sync.setSaving(false);
       } catch (error) {
         sync.setSaving(error);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -29,7 +29,8 @@ import {
   AnnotationShape,
   IDatasetView,
   IContrast,
-  IMapEntry
+  IMapEntry,
+  IHistoryEntry
 } from "./model";
 
 import persister from "./Persister";
@@ -38,6 +39,8 @@ import sync from "./sync";
 import { MAX_NUMBER_OF_RECENT_DATASET_VIEWS } from "./constants";
 import Vue from "vue";
 export { default as store } from "./root";
+
+import { Debounce } from "@/utils/debounce";
 
 @Module({ dynamic: true, store, name: "main" })
 export class Main extends VuexModule {
@@ -53,6 +56,8 @@ export class Main extends VuexModule {
   propertiesAPI = new PropertiesAPI(this.girderRest);
 
   girderUser: IGirderUser | null = this.girderRest.user;
+
+  history: IHistoryEntry[] = [];
 
   selectedDatasetId: string | null = null;
   dataset: IDataset | null = null;
@@ -341,6 +346,11 @@ export class Main extends VuexModule {
   }
 
   @Mutation
+  protected setHistory(history: IHistoryEntry[]) {
+    this.history = history;
+  }
+
+  @Mutation
   private setXYImpl(value: number) {
     this.xy = value;
   }
@@ -425,6 +435,18 @@ export class Main extends VuexModule {
     } catch (error) {
       sync.setLoading(error);
     }
+  }
+
+  @Action
+  setupWatchers() {
+    store.watch(
+      (state: any) => state.annotation.annotations,
+      this.fetchHistory
+    );
+    store.watch(
+      (state: any) => state.annotation.annotationConnections,
+      this.fetchHistory
+    );
   }
 
   @Action
@@ -704,6 +726,13 @@ export class Main extends VuexModule {
     } catch (error) {
       sync.setSaving(error);
     }
+  }
+
+  @Action
+  @Debounce(100, { leading: false, trailing: true })
+  async fetchHistory() {
+    const history = await this.api.getHistoryEntries();
+    this.setHistory(history);
   }
 
   @Action

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1,6 +1,12 @@
 import { IGirderItem } from "@/girder";
 import { ITileHistogram } from "./images";
 
+export interface IHistoryEntry {
+  actionName: string;
+  isUndone: boolean;
+  actionDate: Date;
+}
+
 export interface IFrameInfo {
   DeltaT: number;
   PositionX: number;

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,14 @@
+import { debounce } from "lodash-es";
+
+/**
+ * Debounce decorator for a function
+ * @param debounceArgs The arguments given to the original "debounce" after the function (wait and DebounceSettings)
+ */
+export function Debounce(...debounceArgs: any[]) {
+  return function decorator(_target: any, _name: any, descriptor: any) {
+    const original = descriptor.value;
+    const debounced = debounce(original, ...debounceArgs);
+    descriptor.value = debounced;
+    return descriptor;
+  };
+}


### PR DESCRIPTION
Add Undo/Redo feature
Add an history to the database which contains history entries used to undo/redo recordable actions.

Mechanism to record an API call:
- All models in the database inherit `ProxiedAccessControlledModel` (except for History)
- The endpoint method is decorated with `@recordable(...)` (and eventually `@cacheBodyJson`)
- The recordable decorator first call a girder event starting the recording for all `ProxiedAccessControlledModel`
- It calls the original endpoint function ; the calls of the endpoint function to models method (`save`, `remove`, ...) are recorded by the `ProxiedAccessControlledModel`
- It calls a girder event stoping the recording for all `ProxiedAccessControlledModel` and gathering the records
- It adds the history entry to the database

Close #412 