### PR TITLE
Adjust docker to use the latest master of large_image.

### DIFF
--- a/devops/girder/Dockerfile
+++ b/devops/girder/Dockerfile
@@ -8,7 +8,9 @@ WORKDIR /src
 
 RUN git clone https://github.com/girder/large_image.git
 WORKDIR /src/large_image
-RUN pip install .[all] ./girder[tasks] girder[mount] --find-links https://girder.github.io/large_image_wheels
+RUN pip install -e .[all] -r requirements-test.txt --find-links https://girder.github.io/large_image_wheels
+RUN pip install girder[mount]
+# RUN pip install .[all] ./girder[tasks] girder[mount] --find-links https://girder.github.io/large_image_wheels
 RUN girder build
 
 COPY plugins/AnnotationPlugin /src/AnnotationPlugin


### PR DESCRIPTION
We were inconsistently using master for large_image, but the versioned packages for all of the sources.  We should do one or the other; this uses the master.  Otherwise, we should have just pip installed large_image[all] (and girder[mount]) without cloning the large_image repo.

Note, currently using large_image master enables image conversion on the local instance rather than using the worker.  This will make it easier to test transcoding images on a deployed instance to see if that results in substantial speed gains.