### PR TITLE
Change when we schedule caching tile_frames and maxmerge

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -675,7 +675,7 @@ export class Main extends VuexModule {
     parentId: string;
     metadata: string;
     transcode: boolean;
-    eventCallback?: (data: IJobEventData) => void;
+    eventCallback?: (data: IJobEventData | null) => void;
   }) {
     try {
       sync.setSaving(true);
@@ -721,8 +721,9 @@ export class Main extends VuexModule {
         if (!success) {
           throw new Error("Failed to transcode the large image: job failed");
         }
+      } else if (eventCallback) {
+        eventCallback(null);
       }
-
       return itemId;
     } catch (error) {
       sync.setSaving(error as Error);

--- a/src/views/dataset/MultiSourceConfiguration.vue
+++ b/src/views/dataset/MultiSourceConfiguration.vue
@@ -737,10 +737,12 @@ export default class MultiSourceConfiguration extends Vue {
 
     this.logs = "";
     this.isUploading = true;
-    const eventCallback = (jobData: IJobEventData) => {
-      if (jobData.text) {
+    const eventCallback = (jobData: IJobEventData | null) => {
+      if (jobData && jobData.text) {
         this.logs += jobData.text;
       }
+      this.store.scheduleTileFramesComputation(this.datasetId);
+      this.store.scheduleMaxMergeCache(this.datasetId);
     };
 
     try {

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -223,11 +223,6 @@ export default class NewDataset extends Vue {
   nextStep() {
     this.hideUploader = true;
 
-    if (this.dataset?.id) {
-      this.store.scheduleTileFramesComputation(this.dataset.id);
-      this.store.scheduleMaxMergeCache(this.dataset.id);
-    }
-
     this.$router.push({
       name: "multi",
       params: {


### PR DESCRIPTION
We were scheduling these when a file was uploaded, but then converting that item into a different record via the multi-source file.  This largely invalidated the usefulness of the tile_frames and maxmerge, especially if the multi-source file was not a direct pass through.

This moves the scheduling of these to after the multi-source file becomes a large image or is transcoded into a tiff.