### PR TITLE
Add image scale settings

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -1050,14 +1050,20 @@ export default class ImageViewer extends Vue {
 .progress .v-progress-linear__content {
   position: relative;
 }
+
 .geojs-map .geojs-layer {
   mix-blend-mode: lighten;
 }
-.scale-widget {
-  background-color: #fff2;
+
+.geojs-scale-widget-bar {
+  stroke: white;
 }
+
+.geojs-scale-widget-text {
+  fill: white;
+}
+
 .scale-widget:hover {
-  background-color: #fff8;
   cursor: pointer;
 }
 </style>

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -1,5 +1,19 @@
 <template>
   <div class="image" v-mousetrap="mousetrapAnnotations">
+    <v-dialog v-model="scaleDialog">
+      <v-card>
+        <v-card-title>
+          Scale settings
+        </v-card-title>
+        <v-card-text>
+          <scale-settings />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn class="ma-2" @click="scaleDialog = false">Close</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <annotation-viewer
       v-for="(mapentry, index) in maps.filter(
         mapentry =>
@@ -120,7 +134,9 @@ import setFrameQuad, { ISetQuadStatus } from "@/utils/setFrameQuad";
 
 import AnnotationViewer from "@/components/AnnotationViewer.vue";
 import ImageOverview from "@/components/ImageOverview.vue";
+import ScaleSettings from "@/components/ScaleSettings.vue";
 import { ITileHistogram } from "@/store/images";
+import { convertLength } from "@/utils/conversion";
 import jobs, { jobStates } from "@/store/jobs";
 
 function generateFilterURL(
@@ -176,7 +192,7 @@ function generateFilterURL(
   setSlopeIntercept(index, "func-b", whitePoint, blackPoint, blue);
 }
 
-@Component({ components: { AnnotationViewer, ImageOverview } })
+@Component({ components: { AnnotationViewer, ImageOverview, ScaleSettings } })
 export default class ImageViewer extends Vue {
   readonly store = store;
   readonly annotationStore = annotationStore;
@@ -225,6 +241,8 @@ export default class ImageViewer extends Vue {
   private readyLayers: boolean[] = [];
 
   private resetMapsOnDraw = false;
+
+  scaleDialog = false;
 
   get maps() {
     return this.store.maps;
@@ -643,21 +661,33 @@ export default class ImageViewer extends Vue {
         mapentry.uiLayer = map.createLayer("ui");
         mapentry.uiLayer.node().css({ "mix-blend-mode": "unset" });
       }
+      const pixelSizeScale = this.store.scales.pixelSize;
+      const pixelSizeM = convertLength(
+        pixelSizeScale.value,
+        pixelSizeScale.unit,
+        "m"
+      );
       if (
         mapentry.scaleWidget &&
-        !(
-          someImage.mm_x ||
-          mapentry.scaleWidget.options("scale") !== someImage.mm_x / 1000
-        )
+        (mapentry.scaleWidget.options("scale") !== pixelSizeM ||
+          !this.store.showScalebar)
       ) {
         mapentry.uiLayer.deleteWidget(mapentry.scaleWidget);
         mapentry.scaleWidget = null;
       }
-      if (someImage.mm_x && !mapentry.scaleWidget) {
+      if (!mapentry.scaleWidget && this.store.showScalebar) {
         mapentry.scaleWidget = mapentry.uiLayer.createWidget("scale", {
-          scale: someImage.mm_x / 1000,
+          scale: pixelSizeM,
           position: { bottom: 20, right: 10 }
         });
+        const svgElement: SVGElement = mapentry.scaleWidget.parentCanvas()
+          .firstChild;
+        svgElement.classList.add("scale-widget");
+        svgElement.onclick = (event: MouseEvent) => {
+          event.preventDefault();
+          event.stopPropagation();
+          this.scaleDialog = true;
+        };
       }
     }
   }
@@ -1020,6 +1050,16 @@ export default class ImageViewer extends Vue {
 .progress .v-progress-linear__content {
   position: relative;
 }
+.geojs-map .geojs-layer {
+  mix-blend-mode: lighten;
+}
+.scale-widget {
+  background-color: #fff2;
+}
+.scale-widget:hover {
+  background-color: #fff8;
+  cursor: pointer;
+}
 </style>
 
 <style lang="scss" scoped>
@@ -1090,10 +1130,5 @@ export default class ImageViewer extends Vue {
   width: 25%;
   height: 25%;
   display: inline-block;
-}
-</style>
-<style lang="scss">
-.geojs-map .geojs-layer {
-  mix-blend-mode: lighten;
 }
 </style>

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -678,6 +678,8 @@ export default class ImageViewer extends Vue {
       if (!mapentry.scaleWidget && this.store.showScalebar) {
         mapentry.scaleWidget = mapentry.uiLayer.createWidget("scale", {
           scale: pixelSizeM,
+          strokeWidth: 5,
+          tickLength: 0,
           position: { bottom: 20, right: 10 }
         });
         const svgElement: SVGElement = mapentry.scaleWidget.parentCanvas()
@@ -1061,6 +1063,10 @@ export default class ImageViewer extends Vue {
 
 .geojs-scale-widget-text {
   fill: white;
+}
+
+.scale-widget {
+  overflow: visible;
 }
 
 .scale-widget:hover {

--- a/src/components/ScaleSettings.vue
+++ b/src/components/ScaleSettings.vue
@@ -1,0 +1,213 @@
+<template>
+  <v-list two-line>
+    <v-list-item v-for="(item, i) in scaleItems" :key="`item-${i}`">
+      <v-list-item-content>
+        <span class="d-flex align-center">
+          <div style="min-width: 10em;">
+            {{ item.text }}
+          </div>
+          <v-text-field
+            :value="scales[item.key].value"
+            @input="setScaleValueForItem(item, $event)"
+            class="mx-2"
+            hide-details
+            dense
+            type="number"
+          />
+          <v-select
+            :value="scales[item.key].unit"
+            @input="setUnitValueForItem(item, $event)"
+            class="mx-2 small-input"
+            hide-details
+            dense
+            :items="getUnitValues(item.unit)"
+          />
+          <template v-if="!configurationOnly">
+            <div>
+              <v-btn
+                class="ma-1 d-flex"
+                small
+                @click="resetFromDataset(item.key)"
+              >
+                Reset from dataset
+              </v-btn>
+              <v-btn
+                class="ma-1 d-flex"
+                small
+                :disabled="!viewScales[item.key]"
+                @click="revertToCollection(item.key)"
+              >
+                Reset from collection
+              </v-btn>
+              <v-btn
+                class="ma-1 d-flex"
+                small
+                :disabled="!viewScales[item.key]"
+                @click="saveInCollection(item.key)"
+              >
+                Save in collection
+              </v-btn>
+            </div>
+          </template>
+        </span>
+      </v-list-item-content>
+    </v-list-item>
+  </v-list>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from "vue-property-decorator";
+import store from "@/store/index";
+import {
+  IScaleInformation,
+  IScales,
+  TUnitLength,
+  TUnitTime,
+  exampleConfigurationBase,
+  unitLengthOptions,
+  unitTimeOptions
+} from "@/store/model";
+
+import { convertLength, convertTime } from "@/utils/conversion";
+import { getDatasetScales } from "@/store/GirderAPI";
+
+interface IScaleItem {
+  text: string;
+  key: keyof IScales;
+  unit: "time" | "length";
+}
+
+@Component
+export default class ScaleSettings extends Vue {
+  readonly store = store;
+  readonly unitLengthOptions = unitLengthOptions;
+  readonly unitTimeOptions = unitTimeOptions;
+
+  @Prop({ default: false })
+  configurationOnly!: boolean;
+
+  get configuration() {
+    return this.store.configuration;
+  }
+
+  get viewScales() {
+    return this.store.viewScales;
+  }
+
+  get scales() {
+    if (this.configurationOnly) {
+      return this.store.configurationScales;
+    }
+    return { ...this.store.configurationScales, ...this.viewScales };
+  }
+
+  get scaleItems(): IScaleItem[] {
+    const items: IScaleItem[] = [];
+    items.push({
+      text: "Pixel size",
+      key: "pixelSize",
+      unit: "length"
+    });
+    items.push({
+      text: "Z step",
+      key: "zStep",
+      unit: "length"
+    });
+    items.push({
+      text: "Time step",
+      key: "tStep",
+      unit: "time"
+    });
+    return items;
+  }
+
+  defaultSaveScale(
+    key: keyof IScales,
+    scale: IScaleInformation<TUnitLength | TUnitTime>
+  ) {
+    if (this.configurationOnly) {
+      this.store.saveScaleInConfiguration({ itemId: key, scale });
+    } else {
+      this.store.saveScalesInView({ itemId: key, scale });
+    }
+  }
+
+  saveInCollection(key: keyof IScales) {
+    this.store.saveScaleInConfiguration({
+      itemId: key,
+      scale: this.scales[key]
+    });
+    this.revertToCollection(key);
+  }
+
+  revertToCollection(key: keyof IScales) {
+    this.store.resetScalesInView(key);
+  }
+
+  resetFromDataset(key: keyof IScales) {
+    const dataset = this.store.dataset;
+    if (!dataset) {
+      return;
+    }
+    const datasetScales = getDatasetScales(dataset);
+    this.defaultSaveScale(key, datasetScales[key]);
+  }
+
+  setScaleValueForItem(item: IScaleItem, value: string | number) {
+    const newValue = Number(value);
+    if (isNaN(newValue)) {
+      return;
+    }
+    this.defaultSaveScale(item.key, {
+      value: newValue,
+      unit: this.scales[item.key].unit
+    });
+  }
+
+  setUnitValueForItem(item: IScaleItem, newUnit: string) {
+    if (!newUnit) {
+      return;
+    }
+    const scales = this.scales;
+    const oldValue = scales[item.key].value;
+    const oldUnit = scales[item.key].unit;
+    let newValue: number;
+    switch (item.unit) {
+      case "length":
+        newValue = convertLength(
+          oldValue,
+          oldUnit as TUnitLength,
+          newUnit as TUnitLength
+        );
+        break;
+      case "time":
+        newValue = convertTime(
+          oldValue,
+          oldUnit as TUnitTime,
+          newUnit as TUnitTime
+        );
+        break;
+    }
+    this.defaultSaveScale(item.key, {
+      value: newValue,
+      unit: newUnit as any
+    });
+  }
+
+  getUnitValues(unit: IScaleItem["unit"]) {
+    switch (unit) {
+      case "length":
+        return this.unitLengthOptions;
+      case "time":
+        return this.unitTimeOptions;
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.small-input {
+  flex-grow: 0;
+  width: 10em;
+}
+</style>

--- a/src/components/ViewerSettings.vue
+++ b/src/components/ViewerSettings.vue
@@ -13,6 +13,13 @@
           title="Show pixel intensity values when hovering cursor over image"
         />
         <v-switch hide-details dense v-model="overview" label="Show minimap" />
+        <v-switch
+          hide-details
+          dense
+          v-model="showScalebar"
+          label="Show scalebar"
+          title="Show the scalebarwidget on top of the image"
+        />
       </v-container>
     </v-expansion-panel-content>
   </v-expansion-panel>
@@ -40,6 +47,14 @@ export default class ViewerSettings extends Vue {
 
   set overview(value) {
     this.store.setOverview(value);
+  }
+
+  get showScalebar() {
+    return this.store.showScalebar;
+  }
+
+  set showScalebar(value) {
+    this.store.setShowScalebar(value);
   }
 }
 </script>

--- a/src/store/AnnotationsAPI.ts
+++ b/src/store/AnnotationsAPI.ts
@@ -3,13 +3,13 @@ import {
   IAnnotation,
   IAnnotationConnection,
   IAnnotationBase,
-  AnnotationShape,
-  IGeoJSPoint,
   IToolConfiguration,
   IAnnotationConnectionBase,
   IWorkerInterfaceValues,
   IAnnotationLocation,
-  IDisplayLayer
+  IDisplayLayer,
+  IScales,
+  IDataset
 } from "./model";
 
 import { logError } from "@/utils/log";
@@ -202,15 +202,17 @@ export default class AnnotationsAPI {
 
   async computeAnnotationWithWorker(
     tool: IToolConfiguration,
-    datasetId: string,
+    dataset: IDataset,
     metadata: {
       channel: Number;
       location: IAnnotationLocation;
       tile: IAnnotationLocation;
     },
     workerInterface: IWorkerInterfaceValues,
-    layers: IDisplayLayer[]
+    layers: IDisplayLayer[],
+    scales: IScales
   ) {
+    const datasetId = dataset.id;
     const { id, name, type, values } = tool;
     const image = values.image.image;
     const { annotation, connectTo, jobDateTag } = values;
@@ -243,7 +245,8 @@ export default class AnnotationsAPI {
       tags,
       tile: metadata.tile,
       connectTo: augmentedConnectTo,
-      workerInterface
+      workerInterface,
+      scales
     };
     return this.client.post(
       `upenn_annotation/compute?datasetId=${datasetId}`,

--- a/src/store/PropertiesAPI.ts
+++ b/src/store/PropertiesAPI.ts
@@ -9,7 +9,8 @@ import {
   IWorkerInterfaceValues,
   IAnnotationLocation,
   IDisplayLayer,
-  TPropertyHistogram
+  TPropertyHistogram,
+  IScales
 } from "./model";
 
 import { fetchAllPages } from "@/utils/fetch";
@@ -60,8 +61,13 @@ export default class PropertiesAPI {
   async computeProperty(
     propertyId: string,
     datasetId: string,
-    params: IAnnotationProperty
+    property: IAnnotationProperty,
+    scales: IScales
   ) {
+    const params = {
+      ...property,
+      scales
+    };
     return this.client.post(
       `annotation_property/${propertyId}/compute?datasetId=${datasetId}`,
       params

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -546,14 +546,15 @@ export class Annotations extends VuexModule {
     const tile = { XY: main.xy, Z: main.z, Time: main.time };
     const response = await this.annotationsAPI.computeAnnotationWithWorker(
       tool,
-      datasetId,
+      main.dataset,
       {
         location,
         channel,
         tile
       },
       workerInterface,
-      main.layers
+      main.layers,
+      main.scales
     );
 
     // Keep track of running jobs

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -146,6 +146,22 @@ export interface ISnapshot {
 
 export type IDimensionCompatibility = "one" | "multiple";
 
+export type TUnitLength = "nm" | "µm" | "mm" | "m";
+export const unitLengthOptions: TUnitLength[] = ["nm", "µm", "mm", "m"];
+export type TUnitTime = "ms" | "s" | "m" | "h" | "d";
+export const unitTimeOptions: TUnitTime[] = ["ms", "s", "m", "h", "d"];
+
+export interface IScaleInformation<TUnit> {
+  value: number;
+  unit: TUnit;
+}
+
+export interface IScales {
+  pixelSize: IScaleInformation<TUnitLength>;
+  zStep: IScaleInformation<TUnitLength>;
+  tStep: IScaleInformation<TUnitTime>;
+}
+
 export interface IDatasetConfigurationBase {
   compatibility: {
     xyDimensions: IDimensionCompatibility;
@@ -157,6 +173,7 @@ export interface IDatasetConfigurationBase {
   tools: IToolConfiguration[];
   snapshots: ISnapshot[];
   propertyIds: string[];
+  scales: IScales;
 }
 
 export interface IDatasetConfiguration extends IDatasetConfigurationBase {
@@ -171,6 +188,7 @@ export interface IDatasetViewBase {
   layerContrasts: {
     [layerId: string]: IContrast;
   };
+  scales: Partial<IScales>;
   lastViewed: number;
 }
 
@@ -843,21 +861,27 @@ export function copyLayerWithoutPrivateAttributes(
 }
 
 // To get all the keys of IDatasetConfigurationBase without missing one
-export const exampleConfigurationBase: IDatasetConfigurationBase = {
-  compatibility: {
-    xyDimensions: "multiple",
-    zDimensions: "multiple",
-    tDimensions: "multiple",
-    channels: {}
-  },
-  layers: [],
-  tools: [],
-  snapshots: [],
-  propertyIds: []
-};
-
+export function exampleConfigurationBase(): IDatasetConfigurationBase {
+  return {
+    compatibility: {
+      xyDimensions: "multiple",
+      zDimensions: "multiple",
+      tDimensions: "multiple",
+      channels: {}
+    },
+    layers: [],
+    tools: [],
+    snapshots: [],
+    propertyIds: [],
+    scales: {
+      pixelSize: { value: 1, unit: "m" },
+      zStep: { value: 1, unit: "m" },
+      tStep: { value: 1, unit: "s" }
+    }
+  };
+}
 export const configurationBaseKeys = new Set(
-  Object.keys(exampleConfigurationBase)
+  Object.keys(exampleConfigurationBase())
 ) as Set<keyof IDatasetConfigurationBase>;
 
 export enum AnnotationSelectionTypes {

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -286,6 +286,7 @@ export class Properties extends VuexModule {
       return null;
     }
     const datasetId = main.dataset.id;
+    const scales = main.scales;
 
     if (!this.propertyStatuses[property.id]) {
       Vue.set(this.propertyStatuses, property.id, defaultStatus());
@@ -297,7 +298,8 @@ export class Properties extends VuexModule {
     const response = await this.propertiesAPI.computeProperty(
       property.id,
       datasetId,
-      property
+      property,
+      scales
     );
 
     // Keep track of running jobs

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -1,0 +1,36 @@
+import { TUnitLength, TUnitTime } from "@/store/model";
+
+const oneUnitToMeterConversion = {
+  nm: 1e-9,
+  µm: 1e-6,
+  mm: 1e-3,
+  m: 1
+};
+
+export function convertLength(
+  value: number,
+  oldUnit: TUnitLength,
+  newUnit: TUnitLength
+) {
+  const multiplier =
+    oneUnitToMeterConversion[oldUnit] / oneUnitToMeterConversion[newUnit];
+  return multiplier * value;
+}
+
+const oneUnitToSecondConversion = {
+  ms: 1e-3,
+  s: 1,
+  m: 60,
+  h: 3600,
+  d: 86400
+};
+
+export function convertTime(
+  value: number,
+  oldUnit: TUnitTime,
+  newUnit: TUnitTime
+) {
+  const multiplier =
+    oneUnitToSecondConversion[oldUnit] / oneUnitToSecondConversion[newUnit];
+  return multiplier * value;
+}

--- a/src/views/configuration/ConfigurationInfo.vue
+++ b/src/views/configuration/ConfigurationInfo.vue
@@ -48,6 +48,14 @@
     </v-card>
     <v-card class="mb-4">
       <v-card-title>
+        Scale
+      </v-card-title>
+      <v-card-text>
+        <scale-settings :configuration-only="true" />
+      </v-card-text>
+    </v-card>
+    <v-card class="mb-4">
+      <v-card-title>
         Datasets
       </v-card-title>
       <v-card-text>
@@ -112,8 +120,9 @@ import store from "@/store";
 import girderResources from "@/store/girderResources";
 import { IDatasetView, IDisplaySlice } from "@/store/model";
 import { IGirderFolder } from "@/girder";
+import ScaleSettings from "@/components/ScaleSettings.vue";
 
-@Component
+@Component({ components: { ScaleSettings } })
 export default class ConfigurationInfo extends Vue {
   readonly store = store;
   readonly girderResources = girderResources;

--- a/src/views/configuration/DuplicateImportConfiguration.vue
+++ b/src/views/configuration/DuplicateImportConfiguration.vue
@@ -80,17 +80,14 @@ export default class DuplicateImportConfiguration extends Vue {
     }
 
     // Duplicate each configuration and create a view for it
-    const now = Date.now();
     await Promise.all(
       configurations.map(configuration =>
         this.store.api
           .duplicateConfiguration(configuration, parentFolder?._id)
           .then(newConfiguration =>
-            this.store.api.createDatasetView({
+            this.store.createDatasetView({
               configurationId: newConfiguration.id,
-              datasetId: dataset.id,
-              layerContrasts: {},
-              lastViewed: now
+              datasetId: dataset.id
             })
           )
       )

--- a/src/views/configuration/ImportConfiguration.vue
+++ b/src/views/configuration/ImportConfiguration.vue
@@ -35,11 +35,9 @@ export default class ImportConfiguration extends Vue {
     const now = Date.now();
     await Promise.all(
       configurations.map(configuration =>
-        this.store.api.createDatasetView({
+        this.store.createDatasetView({
           configurationId: configuration.id,
-          datasetId: dataset.id,
-          layerContrasts: {},
-          lastViewed: now
+          datasetId: dataset.id
         })
       )
     );

--- a/src/views/configuration/NewConfiguration.vue
+++ b/src/views/configuration/NewConfiguration.vue
@@ -93,11 +93,9 @@ export default class NewConfiguration extends Mapper {
           return;
         }
         if (this.store.dataset) {
-          this.store.api.createDatasetView({
-            datasetId: this.store.dataset.id,
+          this.store.createDatasetView({
             configurationId: config.id,
-            layerContrasts: {},
-            lastViewed: Date.now()
+            datasetId: this.store.dataset.id
           });
         }
         this.$router.push({

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -401,11 +401,9 @@ export default class DatasetInfo extends Vue {
       baseConfig,
       configurationFolder._id
     );
-    await this.store.api.createDatasetView({
-      datasetId: this.dataset.id,
+    await this.store.createDatasetView({
       configurationId: config.id,
-      layerContrasts: {},
-      lastViewed: Date.now()
+      datasetId: this.dataset.id
     });
 
     this.$router.push({
@@ -422,17 +420,17 @@ export default class DatasetInfo extends Vue {
     if (!datasetFolder?.parentId) {
       return;
     }
-    const config = await this.store.api.createConfigurationFromDataset(
-      this.defaultConfigurationName,
-      "",
-      datasetFolder.parentId,
-      this.dataset
-    );
-    const view = await this.store.api.createDatasetView({
-      datasetId: this.dataset.id,
+    const config = await this.store.createConfiguration({
+      name: this.defaultConfigurationName,
+      description: "",
+      folderId: datasetFolder.parentId
+    });
+    if (!config) {
+      return;
+    }
+    const view = await this.store.createDatasetView({
       configurationId: config.id,
-      layerContrasts: {},
-      lastViewed: Date.now()
+      datasetId: this.dataset.id
     });
     this.$router.push({
       name: "datasetview",


### PR DESCRIPTION
Add a new panel in the collection view
Make scalebar clickable, open a dialog to tweak scales

I added most of the features of issue 498:
- In the collection view, the user can set the values for the different scales
- In the image viewer, the user can open a dialog by clicking on the scalebar to have more options. In this dialog, the scale is saved in the dataset view and the user has the option to save the scale in collection and to reset to dataset default. It behaves like the contrasts.
- The scalebar uses the pixel size given in the dataset view or in the configuration.
- Workers have access to scales: `params["scales"]["pixelSize"]` contains both `value` and `unit`

Close #498 