### PR TITLE
Add createMultipleConnections function to client

### DIFF
--- a/devops/girder/annotation_client/annotation_client/annotations.py
+++ b/devops/girder/annotation_client/annotation_client/annotations.py
@@ -7,6 +7,7 @@ PATHS = {
     'annotation_by_dataset': '/upenn_annotation?datasetId={datasetId}',
 
     'connection': '/annotation_connection/',
+    'multiple_connections': '/annotation_connection/multiple',
     'connection_by_id': '/annotation_connection/{connectionId}',
     'connect_to_nearest': '/annotation_connection/connectTo/',
 
@@ -86,6 +87,17 @@ class UPennContrastAnnotationClient:
         :rtype: dict
         """
         return self.client.post(PATHS['multiple_annotations'], json=annotations)
+    
+    def createMultipleConnections(self, connections):
+        """
+        Create multiple connections with the specified metadata.
+        The connections data should match the standard UPennContrast connection schema
+
+        :param list connections: The list of connections metadata
+        :return: The created connection object (Note: will contain the _id field)
+        :rtype: dict
+        """
+        return self.client.post(PATHS['multiple_connections'], json=connections)
 
     def updateAnnotation(self, annotationId, annotation):
         """


### PR DESCRIPTION
I added `createMultipleConnections` function which can be used in the exact same way as `createMultipleAnnotations` but with connections instead of annotations.
To see what a connection should look like, give a look at `ConnectionSchema` in `devops\girder\plugins\AnnotationPlugin\upenncontrast_annotation\server\models\connections.py`.

I copy-paste it here to avoid diving into the sources:
```python
class ConnectionSchema:
    tagsSchema = {
        'type': 'array',
        'items': {
            'type': 'string'
        }
    }

    connectionSchema = {
        '$schema': 'http://json-schema.org/schema#',
        'id': '/girder/plugins/upenncontrast_annotation/models/annotation_connection',
        'type': 'object',
        'properties': {
            'label': {'type': 'string'},
            'parentId': {'type': 'string'},
            'childId': {'type': 'string'},
            'datasetId': {'type': 'string'},
            'tags': tagsSchema
        },
        'required': ['parentId', 'childId', 'datasetId', 'tags']
    }
```


Close #516 