### PR TITLE
Add vue attrs to worker interface

### DIFF
--- a/src/components/WorkerInterfaceValues.vue
+++ b/src/components/WorkerInterfaceValues.vue
@@ -18,6 +18,7 @@
         <v-col class="pa-0 ma-0">
           <v-slider
             v-if="item.type === 'number'"
+            v-bind="item.vueAttrs"
             v-model="interfaceValues[id]"
             :max="item.max"
             :min="item.min"
@@ -39,31 +40,37 @@
           </v-slider>
           <v-text-field
             v-if="item.type === 'text'"
+            v-bind="item.vueAttrs"
             v-model="interfaceValues[id]"
             dense
           ></v-text-field>
           <tag-picker
             v-if="item.type === 'tags'"
+            v-bind="item.vueAttrs"
             v-model="interfaceValues[id]"
           ></tag-picker>
           <layer-select
             :clearable="!item.required"
             v-if="item.type === 'layer'"
+            v-bind="item.vueAttrs"
             v-model="interfaceValues[id]"
           ></layer-select>
           <v-select
             :clearable="!item.required"
             v-if="item.type === 'select'"
+            v-bind="item.vueAttrs"
             v-model="interfaceValues[id]"
             :items="item.items"
           ></v-select>
           <channel-select
             :clearable="!item.required"
             v-if="item.type === 'channel'"
+            v-bind="item.vueAttrs"
             v-model="interfaceValues[id]"
           ></channel-select>
           <v-checkbox
             v-if="item.type === 'checkbox'"
+            v-bind="item.vueAttrs"
             v-model="interfaceValues[id]"
           ></v-checkbox>
         </v-col>

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -406,43 +406,54 @@ export interface IGeoJSAnnotation {
   geojson: () => any;
 }
 
-export interface INumberWorkerInterfaceElement {
+export interface ICommonWorkerInterfaceElement {
+  vueAttrs?: { [vueAttr: string]: any };
+}
+
+export interface INumberWorkerInterfaceElement
+  extends ICommonWorkerInterfaceElement {
   type: "number";
   min?: number;
   max?: number;
   default?: number;
 }
 
-export interface ITextWorkerInterfaceElement {
+export interface ITextWorkerInterfaceElement
+  extends ICommonWorkerInterfaceElement {
   type: "text";
   default?: string;
 }
 
-export interface ITagsWorkerInterfaceElement {
+export interface ITagsWorkerInterfaceElement
+  extends ICommonWorkerInterfaceElement {
   type: "tags";
   default?: string[];
 }
 
-export interface ILayerWorkerInterfaceElement {
+export interface ILayerWorkerInterfaceElement
+  extends ICommonWorkerInterfaceElement {
   type: "layer";
   default?: string | null;
   required?: boolean;
 }
 
-export interface ISelectWorkerInterfaceElement {
+export interface ISelectWorkerInterfaceElement
+  extends ICommonWorkerInterfaceElement {
   type: "select";
   items: string[];
   default?: string;
   required?: boolean;
 }
 
-export interface IChannelWorkerInterfaceElement {
+export interface IChannelWorkerInterfaceElement
+  extends ICommonWorkerInterfaceElement {
   type: "channel";
   default?: number;
   required?: boolean;
 }
 
-export interface ICheckboxWorkerInterfaceElement {
+export interface ICheckboxWorkerInterfaceElement
+  extends ICommonWorkerInterfaceElement {
   type: "checkbox";
   default?: boolean;
 }


### PR DESCRIPTION
Enable controlling the UI of the frontend through the worker interface to some extent.
For example, to add a placeholder for a text item in the interface, one can have this item in its interface:
```python
'Batch XY': {
    'type': 'text',
    'vueAttrs': {
        'placeholder': 'ex. 1-3, 5-8'
    }
},
```
Another example with more attrs:
```python
'Batch XY': {
    'type': 'text',
    'vueAttrs': {
        'placeholder': 'ex. 1-3, 5-8',
        'outlined': True,
        'prefix': 'My batch'
    }
},
```

To get a list of available `vueAttrs`, look at the code in `WorkerInterfaceValues.vue`.
Here, there is a component for each item type.
For example `number` items becom `v-slider` components, `text` become `v-text-field` components...
Items starting with `v-` are vuetify components and the list of available attributes are in the Vue 2 docs (e.g. [the props of `v-text-field`](https://v2.vuetifyjs.com/en/api/v-text-field/#props)).
Other components are in the source code itself (e.g. `tag-picker` → `TagPicker.vue`).

Close #519 
