### PR TITLE
Fix networking mode for worker.

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/tasks.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/tasks.py
@@ -39,8 +39,6 @@ def runJobRequest(image, datasetId, params, request):
             'container_args': containerArgs,
             'remove_container': True,
             'name': '{}_{}_{}'.format(name, datasetId, datetime.datetime.now().timestamp()),
-            # TODO: figure out network configuration and api url discovery
-            'network_mode': 'host',
             # 'girder_result_hooks': [testHook]
         }
     ).job,

--- a/devops/girder/provision.py
+++ b/devops/girder/provision.py
@@ -25,6 +25,10 @@ def provision(opts):
         # tiled frames
         Setting().set('large_image.max_thumbnail_files', 400)
 
+        # This is how the worker addresses the server.  If the worker is on a
+        # separate machine, this would need to change
+        Setting().set('worker.api_url', 'http://girder:8080/api/v1')
+
     # Make sure we have an assetstore
     if Assetstore().findOne() is None:
         Assetstore().createFilesystemAssetstore('Assetstore', '/assetstore')


### PR DESCRIPTION
The worker needs to run in the same network as the rest of the docker containers OR girder must be publicly visible to the worker and to girder_worker both.  By not specifying the network mode of the worker, girder_worker assigns it the same network as girder_worker's container. By specifying http://girder:8080/api/v1 as the alternative worker URL, this is reachable from within that network.