### PR TITLE
Fix getItems limit

### DIFF
--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -279,14 +279,14 @@ export default class GirderAPI {
     return response.data;
   }
 
-  getItems(folderId: string): Promise<IGirderItem[]> {
-    return this.client
-      .get(`item`, {
-        params: {
-          folderId
-        }
-      })
-      .then(r => r.data);
+  async getItems(folderId: string): Promise<IGirderItem[]> {
+    const baseConfig: AxiosRequestConfig = {
+      params: {
+        folderId
+      }
+    };
+    const pages = await fetchAllPages(this.client, "item", baseConfig);
+    return pages.flat();
   }
 
   getImages(folderId: string): Promise<IGirderItem[]> {


### PR DESCRIPTION
Fix issue mentioned in [this comment](https://github.com/Kitware/UPennContrast/pull/582#pullrequestreview-1696172976)
The getItems function used to fetch only the first 50 items