### PR TITLE
Fix API call that required admin privileges

### DIFF
--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -88,8 +88,7 @@ export default class GirderAPI {
     id: string,
     type: IGirderSelectAble["_modelType"],
   ): Promise<IGirderSelectAble> {
-    const config = { params: { type } };
-    const response = await this.client.get(`resource/${id}`, config);
+    const response = await this.client.get(`${type}/${id}`);
     const resource = response.data;
     if (resource) {
       resource._modelType = type;


### PR DESCRIPTION
The fix given by David seems to not cause any issue.
I tested uploading a new dataset, creating tools, properties and running a property worker.
I found no issue for now, maybe I fixed the worker issue without noticing in a different PR.

Close #605
