### PR TITLE
Add an endpoint for adding multiple annotation property values

### DIFF
--- a/devops/girder/annotation_client/annotation_client/annotations.py
+++ b/devops/girder/annotation_client/annotation_client/annotations.py
@@ -12,6 +12,7 @@ PATHS = {
     'connect_to_nearest': '/annotation_connection/connectTo/',
 
     'add_property_values': '/annotation_property_values?datasetId={datasetId}&annotationId={annotationId}',
+    'add_multiple_property_values': '/annotation_property_values/multiple',
     'get_dataset_properties': '/annotation_property_values?datasetId={datasetId}',
     'get_annotation_properties': '/annotation_property_values?datasetId={datasetId}&annotationId={annotationId}',
     'histogram': '/annotation_property_values/histogram?propertyPath={propertyPath}&datasetId={datasetId}&buckets={buckets}'
@@ -216,11 +217,20 @@ class UPennContrastAnnotationClient:
     def addAnnotationPropertyValues(self, datasetId, annotationId, values):
         """
           Save one or multiple computed property values for the specified annotation
+          The recursive_dict_of_numbers can be (and usually is) just a number
           :param str datasetId: The dataset id
           :param str annotationId: The annotation id
-          :param dict values: A dict of values - { [propertyId]: number | Map<string, number> }
+          :param dict values: A dict of values - { [propertyId]: recursive_dict_of_numbers }
         """
         return self.client.post(PATHS['add_property_values'].format(datasetId=datasetId, annotationId=annotationId), json=values)
+
+    def addMultipleAnnotationPropertyValues(self, entries):
+        """
+          Save one or multiple computed property values for the specified annotations
+          The recursive_dict_of_numbers can be (and usually is) just a number
+          :param list entries: A list of property values for an annotation. Each entry is of type { "datasetId": string, "annotationId": string, "values": { [propertyId: string]: recursive_dict_of_numbers } }
+        """
+        return self.client.post(PATHS['add_multiple_property_values'], json=entries)
 
     def getPropertyHistogram(self, propertyPath, datasetId, buckets=255):
         """

--- a/devops/girder/annotation_client/annotation_client/workers.py
+++ b/devops/girder/annotation_client/annotation_client/workers.py
@@ -1,7 +1,6 @@
 import annotation_client.annotations as annotations
 import annotation_client.tiles as tiles
 import girder_client
-import numpy as np
 import urllib
 
 PATHS = {
@@ -124,10 +123,54 @@ class UPennContrastWorkerClient:
         property_values = {self.propertyId: values}
         self.annotationClient.addAnnotationPropertyValues(self.datasetId, annotation['_id'], property_values)
 
-    def add_multiple_annotation_property_values(self, annotation_property_list):
+    def add_multiple_annotation_property_values(self, values):
         """
         Add a list of property values to the annotations
-        :param list annotation_property_list: A list of dictionaries with items "datasetId", "annotationId", "values": { [propertyId: string]: recursive_dict_of_numbers }
+        :param list values: A dict that links a dataset ID to a dict containing a value for each annotation ID
+        Example of valid values:
+        ```
+        {
+            "myDatasetId": {
+                "myAnnotationId": 42,
+                "anotherAnnotationId": 84,
+            },
+            "anotherDatasetId": {
+                "lastAnnotationId": { "x": 0, "y": 1 },
+            }
+        }
+        ```
         """
-        self.annotationClient.addMultipleAnnotationPropertyValues(annotation_property_list)
-
+        # Convert the values to the following format
+        """
+        ```
+        [
+            {
+                'datasetId': 'myDatasetId',
+                'annotationId': 'myAnnotationId',
+                'values': { self.propertyId: 42 },
+            },
+            {
+                'datasetId': 'myDatasetId',
+                'annotationId': 'anotherAnnotationId',
+                'values': { self.propertyId: 84 },
+            },
+            {
+                'datasetId': 'anotherDatasetId',
+                'annotationId': 'lastAnnotationId',
+                'values': { self.propertyId: {'x': 0, 'y': 1} },
+            },
+        ]
+        ```
+        """
+        reformatedValues = []
+        propertyId = self.propertyId
+        for datasetId in values:
+            for annotationId in values[datasetId]:
+                reformatedValues.append({
+                    "datasetId": datasetId,
+                    "annotationId": annotationId,
+                    "values": {
+                        propertyId: values[datasetId][annotationId]
+                    },
+                })
+        self.annotationClient.addMultipleAnnotationPropertyValues(reformatedValues)

--- a/devops/girder/annotation_client/annotation_client/workers.py
+++ b/devops/girder/annotation_client/annotation_client/workers.py
@@ -166,6 +166,7 @@ class UPennContrastWorkerClient:
         propertyId = self.propertyId
         for datasetId in values:
             for annotationId in values[datasetId]:
+                print("datasetId: {datasetId}, annotationId: {annotationId}, valuesDatasetId: {values[datasetId]}")
                 reformatedValues.append({
                     "datasetId": datasetId,
                     "annotationId": annotationId,

--- a/devops/girder/annotation_client/annotation_client/workers.py
+++ b/devops/girder/annotation_client/annotation_client/workers.py
@@ -123,3 +123,11 @@ class UPennContrastWorkerClient:
         """
         property_values = {self.propertyId: values}
         self.annotationClient.addAnnotationPropertyValues(self.datasetId, annotation['_id'], property_values)
+
+    def add_multiple_annotation_property_values(self, annotation_property_list):
+        """
+        Add a list of property values to the annotations
+        :param list annotation_property_list: A list of dictionaries with items "datasetId", "annotationId", "values": { [propertyId: string]: recursive_dict_of_numbers }
+        """
+        self.annotationClient.addMultipleAnnotationPropertyValues(annotation_property_list)
+

--- a/devops/girder/annotation_client/annotation_client/workers.py
+++ b/devops/girder/annotation_client/annotation_client/workers.py
@@ -166,7 +166,7 @@ class UPennContrastWorkerClient:
         propertyId = self.propertyId
         for datasetId in values:
             for annotationId in values[datasetId]:
-                print("datasetId: {datasetId}, annotationId: {annotationId}, valuesDatasetId: {values[datasetId]}")
+                print(f"datasetId: {datasetId}, annotationId: {annotationId}, valuesDatasetId: {values[datasetId]}")
                 reformatedValues.append({
                     "datasetId": datasetId,
                     "annotationId": annotationId,

--- a/devops/girder/annotation_client/annotation_client/workers.py
+++ b/devops/girder/annotation_client/annotation_client/workers.py
@@ -166,7 +166,6 @@ class UPennContrastWorkerClient:
         propertyId = self.propertyId
         for datasetId in values:
             for annotationId in values[datasetId]:
-                print(f"datasetId: {datasetId}, annotationId: {annotationId}, valuesDatasetId: {values[datasetId]}")
                 reformatedValues.append({
                     "datasetId": datasetId,
                     "annotationId": annotationId,

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/propertyValues.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/propertyValues.py
@@ -79,7 +79,7 @@ class AnnotationPropertyValues(ProxiedAccessControlledModel):
     def appendValues(self, creator, values, annotationId, datasetId):
         property_values = {'annotationId': annotationId, 'values': values, 'datasetId': datasetId}
         self.setUserAccess(property_values, user=creator, level=AccessType.ADMIN)
-        self.save(property_values)
+        return self.save(property_values)
 
     def delete(self, propertyId, datasetId):
         # Could use self.collection.updateMany but girder doesn't expose this method


### PR DESCRIPTION
Close #550

This PR is based on PR #651 to avoid a conflict
It should be merged after

You need to rebuild girder to see the effects of this PR

The workers can use the function `addMultipleAnnotationPropertyValues()`
For convenience, here is the signature and documentation of this function:
```python
    def addMultipleAnnotationPropertyValues(self, entries):
        """
          Save one or multiple computed property values for the specified annotations
          The recursive_dict_of_numbers can be (and usually is) just a number
          :param list entries: A list of property values for an annotation. Each entry is of type { "datasetId": string, "annotationId": string, "values": { [propertyId: string]: recursive_dict_of_numbers } }
        """
```
