### PR TITLE
Make dataset view remember last location

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
@@ -40,7 +40,7 @@ class DatasetView(Resource):
             'datasetId': new_document['datasetId'] ,
             'configurationId': new_document['configurationId']
         }
-        cursor = self._datasetViewModel.findWithPermissions(query, user=self.getCurrentUser(), level=AccessType.READ)
+        cursor = self._datasetViewModel.findWithPermissions(query, user=currentUser, level=AccessType.WRITE)
         old_document = next(cursor, None)
         # If it exists, just update the document instead of creating a new one
         if old_document:

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/datasetView.py
@@ -20,6 +20,24 @@ class DatasetViewSchema:
             }
         }
     }
+
+    locationSchema = {
+        'type': 'object',
+        'properties': {
+            'xy': {
+               'type': 'number',
+            },
+            'z': {
+               'type': 'number',
+            },
+            'time': {
+               'type': 'number',
+            },
+        },
+        'required': ['xy', 'z', 'time'],
+        'additionalProperties': False,
+    }
+
     datasetViewSchema = {
         '$schema': 'http://json-schema.org/schema#',
         'id': '/girder/plugins/upenncontrast_annotation/models/datasetView',
@@ -31,13 +49,14 @@ class DatasetViewSchema:
             'configurationId': {
                 'type': 'string'
             },
+            'lastLocation': locationSchema,
             # Associate a contrast to a layer id
             'layerContrasts': {
                 'type': 'object',
                 'additionalProperties': contrastSchema
             }
         },
-        'required': ['datasetId', 'configurationId', 'layerContrasts']
+        'required': ['datasetId', 'configurationId', 'layerContrasts', 'lastLocation']
     }
 
 class DatasetView(ProxiedAccessControlledModel):

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -111,19 +111,6 @@ import { IHotkey } from "@/utils/v-mousetrap";
 export default class ViewerToolbar extends Vue {
   readonly store = store;
 
-  private changeQuery(param: string, value: string) {
-    const old = this.$route.query[param];
-    if (old === value) {
-      return;
-    }
-    this.$router.replace({
-      query: {
-        ...this.$route.query,
-        [param]: value,
-      },
-    });
-  }
-
   get xy() {
     return this.store.xy;
   }
@@ -137,21 +124,15 @@ export default class ViewerToolbar extends Vue {
   }
 
   set xy(value: number) {
-    if (value !== this.xy) {
-      this.changeQuery("xy", value.toString());
-    }
+    this.store.setXY(value);
   }
 
   set z(value: number) {
-    if (value !== this.z) {
-      this.changeQuery("z", value.toString());
-    }
+    this.store.setZ(value);
   }
 
   set time(value: number) {
-    if (value !== this.time) {
-      this.changeQuery("time", value.toString());
-    }
+    this.store.setTime(value);
   }
 
   get unrollXY() {
@@ -159,9 +140,7 @@ export default class ViewerToolbar extends Vue {
   }
 
   set unrollXY(value: boolean) {
-    if (value !== this.unrollXY) {
-      this.changeQuery("unrollXY", value.toString());
-    }
+    this.store.setUnrollXY(value);
   }
 
   @Watch("unrollXY")
@@ -174,9 +153,7 @@ export default class ViewerToolbar extends Vue {
   }
 
   set unrollZ(value: boolean) {
-    if (value !== this.unrollZ) {
-      this.changeQuery("unrollZ", value.toString());
-    }
+    this.store.setUnrollZ(value);
   }
 
   @Watch("unrollZ")
@@ -189,9 +166,7 @@ export default class ViewerToolbar extends Vue {
   }
 
   set unrollT(value: boolean) {
-    if (value !== this.unrollT) {
-      this.changeQuery("unrollT", value.toString());
-    }
+    this.store.setUnrollT(value);
   }
 
   @Watch("unrollT")
@@ -212,9 +187,7 @@ export default class ViewerToolbar extends Vue {
   }
 
   set layerMode(value: TLayerMode) {
-    if (value !== this.layerMode) {
-      this.changeQuery("layer", value);
-    }
+    this.store.setLayerMode(value);
   }
 
   get layerMode() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ Vue.use(vDescription);
 main.initialize();
 main.setupWatchers();
 
-new Vue({
+const app = new Vue({
   provide: {
     // use a proxy to dynamically resolve to the right girderRest client
     girderRest: new Proxy(main, {
@@ -49,3 +49,5 @@ new Vue({
   vuetify,
   render: (h: any) => h(App),
 }).$mount("#app");
+
+export { app };

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -312,7 +312,7 @@ export default class GirderAPI {
     return this.client.delete(`dataset_view/${id}`);
   }
 
-  updateDatasetView(datasetView: IDatasetView) {
+  updateDatasetView(datasetView: Partial<IDatasetView> & { id: string }) {
     return this.client.put(`dataset_view/${datasetView.id}`, datasetView);
   }
 
@@ -709,6 +709,7 @@ function asDatasetView(data: AxiosResponse["data"]): IDatasetView {
     layerContrasts: data.layerContrasts || {},
     scales: data.scales || {},
     lastViewed: data.lastViewed,
+    lastLocation: data.lastLocation || { xy: 0, z: 0, time: 0 },
   };
 }
 

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -294,6 +294,11 @@ export interface IDatasetViewBase {
   };
   scales: Partial<IScales>;
   lastViewed: number;
+  lastLocation: {
+    xy: number;
+    z: number;
+    time: number;
+  };
 }
 
 export interface IDatasetView extends IDatasetViewBase {

--- a/src/views/datasetView/Viewer.vue
+++ b/src/views/datasetView/Viewer.vue
@@ -19,6 +19,7 @@ import ContrastPanels from "@/components/ContrastPanels.vue";
 import store from "@/store";
 import annotationStore from "@/store/annotation";
 import propertiesStore from "@/store/properties";
+import { Debounce } from "@/utils/debounce";
 
 @Component({
   components: {
@@ -56,6 +57,89 @@ export default class Viewer extends Vue {
   @Watch("configuration")
   configurationChanged() {
     this.propertyStore.fetchProperties();
+  }
+
+  async changeQuery(param: string, value: string) {
+    const old = this.$route.query[param];
+    if (old === value) {
+      return;
+    }
+    await this.$router.replace({
+      query: {
+        ...this.$route.query,
+        [param]: value,
+      },
+    });
+  }
+
+  get xy() {
+    return this.store.xy;
+  }
+
+  get z() {
+    return this.store.z;
+  }
+
+  get time() {
+    return this.store.time;
+  }
+
+  get unrollXY() {
+    return this.store.unrollXY;
+  }
+
+  get unrollZ() {
+    return this.store.unrollZ;
+  }
+
+  get unrollT() {
+    return this.store.unrollT;
+  }
+
+  get layerMode() {
+    return this.store.layerMode;
+  }
+
+  @Watch("xy")
+  @Debounce(500)
+  updateQueryParamsXY() {
+    this.changeQuery("xy", this.xy.toString());
+  }
+
+  @Watch("z")
+  @Debounce(500)
+  updateQueryParamsZ() {
+    this.changeQuery("z", this.z.toString());
+  }
+
+  @Watch("time")
+  @Debounce(500)
+  updateQueryParamsT() {
+    this.changeQuery("time", this.time.toString());
+  }
+
+  @Watch("unrollXY")
+  @Debounce(500)
+  updateQueryParamsUnrollXY() {
+    this.changeQuery("unrollXY", this.unrollXY.toString());
+  }
+
+  @Watch("unrollZ")
+  @Debounce(500)
+  updateQueryParamsUnrollZ() {
+    this.changeQuery("unrollZ", this.unrollZ.toString());
+  }
+
+  @Watch("unrollT")
+  @Debounce(500)
+  updateQueryParamsUnrollT() {
+    this.changeQuery("unrollT", this.unrollT.toString());
+  }
+
+  @Watch("layerMode")
+  @Debounce(500)
+  updateQueryParamsLayerMode() {
+    this.changeQuery("layer", this.layerMode);
   }
 }
 </script>


### PR DESCRIPTION
If you stay more than 5 seconds at the same location, the last location is saved in the dataset view
When reopening the the same dataset view, the location will be the same as before
If the url query contains a location (for example `z=9`), it will override the last location saved in the dataset view

Close #654
