### PR TITLE
Fix overview scale

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -893,7 +893,7 @@ export default class ImageViewer extends Vue {
       }
       this.scaleWidget = null;
     }
-    if (!this.scaleWidget && this.showScalebar) {
+    if (!this.scaleWidget && this.showScalebar && pixelSizeM > 0) {
       this.scaleWidget = uiLayer.createWidget("scale", {
         scale: pixelSizeM,
         strokeWidth: 5,


### PR DESCRIPTION
Fix the scale of the image overview in the minimap

Another very small change: the scalebar throws errors in the console when the scale is at 0 and the scalebar doesn't show up
So I removed the scalebar when the scale is 0 to avoid errors, this shouldn't change anything for the user