### PR TITLE
Add a patch to fix mousetrap

### DIFF
--- a/patches/mousetrap+1.6.5.patch
+++ b/patches/mousetrap+1.6.5.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/mousetrap/plugins/record/mousetrap-record.js b/node_modules/mousetrap/plugins/record/mousetrap-record.js
+index b7d364d..97e815f 100644
+--- a/node_modules/mousetrap/plugins/record/mousetrap-record.js
++++ b/node_modules/mousetrap/plugins/record/mousetrap-record.js
+@@ -58,6 +58,7 @@
+      */
+     function _handleKey(character, modifiers, e) {
+         var self = this;
++        var i;
+ 
+         if (!self.recording) {
+             _origHandleKey.apply(self, arguments);
+diff --git a/node_modules/mousetrap/plugins/record/mousetrap-record.min.js b/node_modules/mousetrap/plugins/record/mousetrap-record.min.js
+index 25f3e71..a50a14e 100644
+--- a/node_modules/mousetrap/plugins/record/mousetrap-record.min.js
++++ b/node_modules/mousetrap/plugins/record/mousetrap-record.min.js
+@@ -1,2 +1,2 @@
+-(function(d){function n(b,a,h){if(this.recording)if("keydown"==h.type){1===b.length&&g&&k();for(i=0;i<a.length;++i)l(a[i]);l(b)}else"keyup"==h.type&&0<c.length&&k();else p.apply(this,arguments)}function l(b){var a;for(a=0;a<c.length;++a)if(c[a]===b)return;c.push(b);1===b.length&&(g=!0)}function k(){e.push(c);c=[];g=!1;clearTimeout(m);m=setTimeout(q,1E3)}function r(b){var a;for(a=0;a<b.length;++a)b[a].sort(function(a,b){return 1<a.length&&1===b.length?-1:1===a.length&&1<b.length?1:a>b?1:-1}),b[a]=
++(function(d){function n(b,a,h){if(this.recording)if("keydown"==h.type){1===b.length&&g&&k();var i;for(i=0;i<a.length;++i)l(a[i]);l(b)}else"keyup"==h.type&&0<c.length&&k();else p.apply(this,arguments)}function l(b){var a;for(a=0;a<c.length;++a)if(c[a]===b)return;c.push(b);1===b.length&&(g=!0)}function k(){e.push(c);c=[];g=!1;clearTimeout(m);m=setTimeout(q,1E3)}function r(b){var a;for(a=0;a<b.length;++a)b[a].sort(function(a,b){return 1<a.length&&1===b.length?-1:1===a.length&&1<b.length?1:a>b?1:-1}),b[a]=
+ b[a].join("+")}function q(){f&&(r(e),f(e));e=[];f=null;c=[]}var e=[],f=null,c=[],g=!1,m=null,p=d.prototype.handleKey;d.prototype.record=function(b){var a=this;a.recording=!0;f=function(){a.recording=!1;b.apply(a,arguments)}};d.prototype.handleKey=function(){n.apply(this,arguments)};d.init()})(Mousetrap);


### PR DESCRIPTION
Before moving to vite, a declaration of "i" was probably leaking into the plugin
If this still doesn't work, make sure the patch is applied by running `npm run dev -- --force`
D3 and mousetrap should be upgraded / replaced instead of being patched

Close #668 