### PR TITLE
Changed to chip selection

### DIFF
--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -517,7 +517,9 @@ tbody tr.is-hovered:hover {
 }
 
 .v-chip {
-  transition: background-color 0.3s, color 0.3s; /* Smooth transition */
+  transition:
+    background-color 0.3s,
+    color 0.3s; /* Smooth transition */
 }
 
 td span {

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -44,15 +44,23 @@
       </v-dialog>
       <v-row>
         <v-col cols="12" md="6">
-          <v-select
+          <v-chip-group
             v-model="selectedColumns"
-            :items="columnOptions"
-            attach
-            chips
-            label="Select columns"
+            column
             multiple
-            small-chips
-          ></v-select>
+            active-class="selected-chip"
+          >
+            <v-chip
+              v-for="option in columnOptions"
+              :key="option.value"
+              :value="option.value"
+              :class="{'selected-chip': selectedColumns.includes(option.value)}"
+              outlined
+              x-small
+            >
+              {{ option.text }}
+            </v-chip>
+          </v-chip-group>
         </v-col>
         <v-col cols="12" md="6">
           <v-text-field
@@ -500,6 +508,14 @@ tbody tr.is-hovered:hover {
 
 .v-input__slot {
   justify-content: center;
+}
+
+.selected-chip {
+  border-color: #ffffff !important; /* Change to your preferred color */
+}
+
+.v-chip {
+  transition: background-color 0.3s, color 0.3s; /* Smooth transition */
 }
 
 td span {

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -54,7 +54,9 @@
               v-for="option in columnOptions"
               :key="option.value"
               :value="option.value"
-              :class="{'selected-chip': selectedColumns.includes(option.value)}"
+              :class="{
+                'selected-chip': selectedColumns.includes(option.value),
+              }"
               outlined
               x-small
             >


### PR DESCRIPTION
@bruyeret I changed the selection thing for the columns to something that I think is more intuitive. It basically works, but it doesn't look quite as good when the interface is in light mode. The problem is that when a chip is selected, it looks like it is active, even if it is not active. In dark mode, it looks fine because the white outline dominates. But the underlying issue is still there. I couldn't figure out how to change the styling. Anyway, overall, it is still an improvement, so we can also just merge the PR, but if you have any quick fixes, go for it!