### PR TITLE
Put tool list in bigger panel

### DIFF
--- a/public/config/templates.json
+++ b/public/config/templates.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Manual annotation tool",
+    "name": "Manual object tool",
     "type": "create",
     "shortName": "Manual",
     "interface": [
@@ -125,7 +125,7 @@
     ]
   },
   {
-    "name": "Select annotation tools",
+    "name": "Selection tools",
     "type": "select",
     "interface": [
       {
@@ -144,55 +144,6 @@
               "value": "lasso"
             }
           ]
-        }
-      }
-    ]
-  },
-  {
-    "name": "Annotation Connections",
-    "type": "connection",
-    "shortName": "Connection",
-    "interface": [
-      {
-        "name": "Action",
-        "type": "select",
-        "id": "action",
-        "isSubmenu": true,
-        "meta": {
-          "items": [
-            {
-              "text": "Lasso connect",
-              "value": "add_lasso"
-            },
-            {
-              "text": "Click connect",
-              "value": "add_click"
-            },
-            {
-              "text": "Lasso disconnect",
-              "value": "delete_lasso"
-            },
-            {
-              "text": "Click disconnect",
-              "value": "delete_click"
-            }
-          ]
-        }
-      },
-      {
-        "name": "Parent Annotation",
-        "id": "parentAnnotation",
-        "type": "restrictTagsAndLayer",
-        "meta": {
-          "inclusiveToggle": true
-        }
-      },
-      {
-        "name": "Child Annotation",
-        "id": "childAnnotation",
-        "type": "restrictTagsAndLayer",
-        "meta": {
-          "inclusiveToggle": true
         }
       }
     ]
@@ -274,7 +225,7 @@
     ]
   },
   {
-    "name": "Automated annotation tools",
+    "name": "Automated object finding tools",
     "type": "segmentation",
     "shortName": "Automated",
     "comment": "TODO: ROI selection, auto annotation tags    ",
@@ -314,7 +265,7 @@
     ]
   },
   {
-    "name": "Segment Anything Annotation (experimental, WebGPU only)",
+    "name": "Segment Anything Model (experimental, Chrome/WebGPU only)",
     "type": "samAnnotation",
     "shortName": "SAM",
     "interface": [
@@ -355,6 +306,55 @@
         "type": "checkbox",
         "meta": {
           "label": "Enable submit of annotation on prompt"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Annotation Connections",
+    "type": "connection",
+    "shortName": "Connection",
+    "interface": [
+      {
+        "name": "Action",
+        "type": "select",
+        "id": "action",
+        "isSubmenu": true,
+        "meta": {
+          "items": [
+            {
+              "text": "Lasso connect",
+              "value": "add_lasso"
+            },
+            {
+              "text": "Click connect",
+              "value": "add_click"
+            },
+            {
+              "text": "Lasso disconnect",
+              "value": "delete_lasso"
+            },
+            {
+              "text": "Click disconnect",
+              "value": "delete_click"
+            }
+          ]
+        }
+      },
+      {
+        "name": "Parent Annotation",
+        "id": "parentAnnotation",
+        "type": "restrictTagsAndLayer",
+        "meta": {
+          "inclusiveToggle": true
+        }
+      },
+      {
+        "name": "Child Annotation",
+        "id": "childAnnotation",
+        "type": "restrictTagsAndLayer",
+        "meta": {
+          "inclusiveToggle": true
         }
       }
     ]

--- a/src/tools/creation/ToolTypeSelection.vue
+++ b/src/tools/creation/ToolTypeSelection.vue
@@ -1,12 +1,20 @@
 <template>
   <v-container>
     <v-btn @click="toggleMenu" class="big-subheaders">
-      {{ selectedItem ? selectedItem.text : 'Select Tool Type' }}
+      {{ selectedItem ? selectedItem.text : "Select Tool Type" }}
     </v-btn>
-    <v-menu v-model="menuVisible" :close-on-content-click="false" :activator="activator">
+    <v-menu
+      v-model="menuVisible"
+      :close-on-content-click="false"
+      :activator="activator"
+    >
       <v-list class="floating-list">
         <template v-for="item in submenuItems">
-          <v-subheader v-if="item.header" :key="item.header" class="custom-subheader">
+          <v-subheader
+            v-if="item.header"
+            :key="item.header"
+            class="custom-subheader"
+          >
             {{ item.header }}
           </v-subheader>
           <v-list-item

--- a/src/tools/creation/ToolTypeSelection.vue
+++ b/src/tools/creation/ToolTypeSelection.vue
@@ -69,7 +69,10 @@ export interface TReturnType {
   selectedItem: AugmentedItem | null;
 }
 
-const hiddenToolTexts = new Set<string>(["\"Snap to\" manual annotation tools", "Annotation edit tools"]);
+const hiddenToolTexts = new Set<string>([
+  '"Snap to" manual annotation tools',
+  "Annotation edit tools",
+]);
 
 @Component({
   components: {

--- a/src/tools/creation/ToolTypeSelection.vue
+++ b/src/tools/creation/ToolTypeSelection.vue
@@ -69,7 +69,7 @@ export interface TReturnType {
   selectedItem: AugmentedItem | null;
 }
 
-const hiddenToolTexts = new Set<string>([]);
+const hiddenToolTexts = new Set<string>(["\"Snap to\" manual annotation tools", "Annotation edit tools"]);
 
 @Component({
   components: {

--- a/src/tools/creation/ToolTypeSelection.vue
+++ b/src/tools/creation/ToolTypeSelection.vue
@@ -1,26 +1,28 @@
 <template>
   <v-container>
-    <v-btn @click="toggleMenu" class="big-subheaders">
-      {{ selectedItem ? selectedItem.text : "Select Tool Type" }}
-    </v-btn>
-    <v-menu
-      v-model="menuVisible"
-      :close-on-content-click="false"
-      :activator="activator"
-    >
+    <v-menu offset-x right>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn v-bind="attrs" v-on="on" class="big-subheaders">
+          {{ selectedItem ? selectedItem.text : "Select Tool Type" }}
+        </v-btn>
+      </template>
       <v-list class="floating-list">
-        <template v-for="item in submenuItems">
+        <template v-for="(item, itemIndex) in submenuItems">
           <v-subheader
-            v-if="item.header"
+            v-if="'header' in item"
             :key="item.header"
             class="custom-subheader"
           >
             {{ item.header }}
           </v-subheader>
+          <v-divider
+            v-else-if="'divider' in item"
+            :key="`divider-${itemIndex}`"
+          />
           <v-list-item
-            v-if="!item.header && !item.divider"
+            v-else-if="'key' in item"
             :key="item.key"
-            @click="selectItem(item)"
+            @click="selectedItem = item"
             dense
           >
             <v-list-item-content>
@@ -82,7 +84,6 @@ export default class ToolTypeSelection extends Vue {
   computedTemplate: IToolTemplate | null = null;
   defaultToolValues: any = {};
 
-  menuVisible = false;
   selectedItem: AugmentedItem | null = null;
 
   get submenuItems() {
@@ -232,17 +233,9 @@ export default class ToolTypeSelection extends Vue {
     this.handleChange();
     this.refreshWorkers();
   }
-
-  toggleMenu() {
-    this.menuVisible = !this.menuVisible;
-  }
-
-  selectItem(item: AugmentedItem) {
-    this.selectedItem = item;
-    this.menuVisible = false;
-  }
 }
 </script>
+
 <style lang="scss" scoped>
 .floating-list {
   display: flex;
@@ -257,23 +250,6 @@ export default class ToolTypeSelection extends Vue {
   font-size: large;
   text-align: left;
   padding: 8px 16px;
-}
-
-.v-list-item {
-  padding: 8px 16px;
-}
-
-.v-list-item-title {
-  font-size: medium;
-}
-
-.v-list-item-subtitle {
-  font-size: small;
-  color: rgba(0, 0, 0, 0.6);
-}
-
-.v-select__selections {
-  margin: 0 !important;
 }
 </style>
 


### PR DESCRIPTION
@bruyeret I made the tool list bigger and made it come from a button. I think the interface is a bit more discoverable now, because the list of items was so long. The only problem is that the floating panel is now to the left of the button, would be better to the right of the button, I think. Also, we have a lot of old tools or non-functional tools. Perhaps we can comment them out for now?