### PR TITLE
Use private folder by default

### DIFF
--- a/devops/girder/provision.py
+++ b/devops/girder/provision.py
@@ -21,7 +21,7 @@ def provision(opts):
         # Allow cross origin requests, but since this may be undesired,
         # only do it if we are creating an admin user so it doesn't happen
         # on subsequent starts.
-        Setting().set("core.cors.allow_origin", "*")
+        Setting().set("core.cors.allow_origin", "http://localhost:*")
 
         # Increase the allowed files that can be cached, as this is used for
         # tiled frames

--- a/src/components/CustomFileManager.vue
+++ b/src/components/CustomFileManager.vue
@@ -184,8 +184,8 @@ export default class CustomFileManager extends Vue {
 
   @Watch("isLoggedIn")
   async fetchLocation() {
-    const publicFolder = await this.store.api.getUserPrivateFolder();
-    this.defaultLocation = publicFolder || this.store.girderUser;
+    const privateFolder = await this.store.api.getUserPrivateFolder();
+    this.defaultLocation = privateFolder || this.store.girderUser;
   }
 
   @Watch("selected")

--- a/src/components/CustomFileManager.vue
+++ b/src/components/CustomFileManager.vue
@@ -184,7 +184,7 @@ export default class CustomFileManager extends Vue {
 
   @Watch("isLoggedIn")
   async fetchLocation() {
-    const publicFolder = await this.store.api.getUserPublicFolder();
+    const publicFolder = await this.store.api.getUserPrivateFolder();
     this.defaultLocation = publicFolder || this.store.girderUser;
   }
 

--- a/src/components/ImageOverview.vue
+++ b/src/components/ImageOverview.vue
@@ -187,7 +187,7 @@ export default class ImageViewer extends Vue {
       someImage.tileWidth,
       someImage.tileHeight,
     );
-    params.layer.useCredentials = true;
+    params.layer.crossDomain = "use-credentials";
     params.layer.url = "";
     params.layer.renderer = "canvas";
     /* We want the actions to trigger on the overview, but affect the main

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -802,7 +802,7 @@ export default class ImageViewer extends Vue {
     );
     params.map.zoom = params.map.min;
     params.map.center = { x: mapWidth / 2, y: mapHeight / 2 };
-    params.layer.useCredentials = true;
+    params.layer.crossDomain = "use-credentials";
     params.layer.autoshareRenderer = false;
     params.layer.nearestPixel = params.layer.maxLevel;
     delete params.layer.tilesMaxBounds;

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -108,7 +108,14 @@ export default class GirderAPI {
     return users.map((user: IGirderUser) => user._id);
   }
 
-  async getUserPublicFolder(userId?: string): Promise<IGirderFolder | null> {
+  getUserPrivateFolder(userId?: string): Promise<IGirderFolder | null> {
+    return this.getUserFolder("Private", userId);
+  }
+
+  async getUserFolder(
+    folderName: string,
+    userId?: string,
+  ): Promise<IGirderFolder | null> {
     let parentId = userId;
     if (userId === undefined) {
       const me = await this.client.get("user/me");
@@ -121,7 +128,7 @@ export default class GirderAPI {
     }
 
     const result = await this.client.get(
-      `folder?parentType=user&parentId=${parentId}&name=Public`,
+      `folder?parentType=user&parentId=${parentId}&name=${folderName}`,
     );
     return result.data.length > 0 ? result.data[0] : null;
   }

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -396,20 +396,6 @@ export default class GirderAPI {
     return this.client.post("folder", data).then((r) => asDataset(r.data));
   }
 
-  async getQuickUploadFolder(parentId: string) {
-    const data = new FormData();
-    data.set("parentType", "folder");
-    data.set("parentId", parentId);
-    data.set("name", "QuickUpload");
-    data.set(
-      "description",
-      "Contains all datasets uploaded using the QuickUpload feature.",
-    );
-    data.set("reuseExisting", "true");
-    const resp = await this.client.post("folder", data);
-    return resp.data;
-  }
-
   importDataset(path: IGirderSelectAble): Promise<IDataset> {
     return this.client
       .put(`/folder/${path._id}/metadata`, {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -416,7 +416,7 @@ export class Main extends VuexModule {
     const promises = [];
     if (user) {
       promises.push(
-        this.api.getUserPublicFolder(user._id).then((publicFolder) => {
+        this.api.getUserPrivateFolder(user._id).then((publicFolder) => {
           if (publicFolder) {
             this.setFolderLocation(publicFolder);
           } else {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -416,9 +416,9 @@ export class Main extends VuexModule {
     const promises = [];
     if (user) {
       promises.push(
-        this.api.getUserPrivateFolder(user._id).then((publicFolder) => {
-          if (publicFolder) {
-            this.setFolderLocation(publicFolder);
+        this.api.getUserPrivateFolder(user._id).then((privateFolder) => {
+          if (privateFolder) {
+            this.setFolderLocation(privateFolder);
           } else {
             this.setFolderLocation(user);
           }

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -565,6 +565,7 @@ export interface IGeoJSLayerSpec {
   id?: number;
   map?: IGeoJSMap | null;
   renderer?: string | IGeoJSRenderer;
+  crossDomain?: "anonymous" | "use-credentials";
   autoshareRenderer?: boolean | string;
   canvas?: HTMLCanvasElement;
   annotations?: string[] | IObject;

--- a/src/utils/setFrameQuad.ts
+++ b/src/utils/setFrameQuad.ts
@@ -76,7 +76,7 @@ export default function setFrameQuad(
   const options: ISetQuadStatusOptions = {
     progress: () => {},
     adjustMinLevel: true,
-    crossOrigin: "anonymous",
+    crossOrigin: "use-credentials",
     redrawOnFirstLoad: true,
     ...partialOptions,
   };

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -333,14 +333,16 @@ export default class NewDataset extends Vue {
     if (this.initialUploadLocation) {
       this.path = this.initialUploadLocation;
     } else {
-      const publicFolder = await this.store.api.getUserPrivateFolder();
-      if (!publicFolder) {
+      const privateFolder = await this.store.api.getUserPrivateFolder();
+      if (!privateFolder) {
         return;
       }
       if (this.quickupload) {
-        this.path = await this.store.api.getQuickUploadFolder(publicFolder._id);
+        this.path = await this.store.api.getQuickUploadFolder(
+          privateFolder._id,
+        );
       } else {
-        this.path = publicFolder;
+        this.path = privateFolder;
       }
     }
   }

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -333,7 +333,7 @@ export default class NewDataset extends Vue {
     if (this.initialUploadLocation) {
       this.path = this.initialUploadLocation;
     } else {
-      const publicFolder = await this.store.api.getUserPublicFolder();
+      const publicFolder = await this.store.api.getUserPrivateFolder();
       if (!publicFolder) {
         return;
       }

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -117,7 +117,7 @@
 import { Vue, Component, Prop } from "vue-property-decorator";
 import store from "@/store";
 import girderResources from "@/store/girderResources";
-import { IGirderSelectAble } from "@/girder";
+import { IGirderLocation } from "@/girder";
 import GirderLocationChooser from "@/components/GirderLocationChooser.vue";
 import FileDropzone from "@/components/Files/FileDropzone.vue";
 import { IDataset } from "@/store/model";
@@ -208,7 +208,7 @@ export default class NewDataset extends Vue {
   readonly autoMultiConfig!: boolean;
 
   @Prop()
-  readonly initialUploadLocation?: IGirderSelectAble;
+  readonly initialUploadLocation!: IGirderLocation;
 
   uploadedFiles: File[] | null = null;
 
@@ -222,7 +222,7 @@ export default class NewDataset extends Vue {
   name = "";
   description = "";
 
-  path: IGirderSelectAble | null = null;
+  path: IGirderLocation | null = null;
 
   dataset: IDataset | null = null;
 
@@ -330,21 +330,7 @@ export default class NewDataset extends Vue {
   }
 
   async mounted() {
-    if (this.initialUploadLocation) {
-      this.path = this.initialUploadLocation;
-    } else {
-      const privateFolder = await this.store.api.getUserPrivateFolder();
-      if (!privateFolder) {
-        return;
-      }
-      if (this.quickupload) {
-        this.path = await this.store.api.getQuickUploadFolder(
-          privateFolder._id,
-        );
-      } else {
-        this.path = privateFolder;
-      }
-    }
+    this.path = this.initialUploadLocation;
   }
 
   async uploadMounted() {
@@ -358,7 +344,7 @@ export default class NewDataset extends Vue {
   }
 
   async submit() {
-    if (!this.valid || !this.path) {
+    if (!this.valid || !this.path || !("_id" in this.path)) {
       return;
     }
 


### PR DESCRIPTION
The default is now the Private folder for everything.
Also fix the datasets that are uploaded in the private folder, as the images didn't send the `girder-token` cookie because of the `crossOrigin` setting of images that was badly set.
Also fix the default CORS allowed origins in girder, because a simple wildcard is not compatible with `crossOrigin="use-credentials"`.

For exisiting builds, that use a different IP for the front end and girder:
In girder (http://localhost:8080/):
- Go to Admin Console -> Server Configuration
- Go to Advanced Settings at the bottom and find `CORS Allowed Origins` setting
- Replace the `*` with the full adress of the backend (for example `http://localhost:5173` or `http://localhost:*`), or even `**` if it is in a private network
- Save the settings
![image](https://github.com/Kitware/UPennContrast/assets/90781029/798c3897-f4d5-4af8-835d-8fab10e5b2f4)


Close #739 