### PR TITLE
Configure automated tool creation panel

### DIFF
--- a/src/store/AnnotationsAPI.ts
+++ b/src/store/AnnotationsAPI.ts
@@ -234,8 +234,8 @@ export default class AnnotationsAPI {
     const datasetId = dataset.id;
     const { id, name, type, values } = tool;
     const image = values.image.image;
-    const { annotation, connectTo, jobDateTag } = values;
-    let tags = annotation.tags;
+    const { annotation = {}, connectTo = {}, jobDateTag } = values;
+    let tags = annotation.tags ?? [];
     if (jobDateTag) {
       const date = new Date(Date.now());
       const timeZone = date.getTimezoneOffset() / 60;
@@ -250,9 +250,9 @@ export default class AnnotationsAPI {
       tags = [...tags, computedTag];
     }
     const connectToLayerId = connectTo.layer;
-    const connectToLayer = layers.find(
-      (layer) => layer.id === connectToLayerId,
-    );
+    const connectToLayer = connectToLayerId
+      ? layers.find((layer) => layer.id === connectToLayerId)
+      : null;
     const connectToChannel = connectToLayer ? connectToLayer.channel : null;
     const augmentedConnectTo = { ...connectTo, channel: connectToChannel };
     const params = {

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -788,7 +788,7 @@ export class Annotations extends VuexModule {
       Time: main.time,
     };
 
-    const layerId = toolAnnotation.coordinateAssignments.layer;
+    const layerId = toolAnnotation?.coordinateAssignments?.layer;
     const layer = layerId ? main.getLayerFromId(layerId) : null;
     const channel = layer?.channel ?? 0;
     if (layer) {
@@ -796,11 +796,14 @@ export class Annotations extends VuexModule {
       if (indexes) {
         const { xyIndex, zIndex, tIndex } = indexes;
         location.XY = xyIndex;
-        const assign = toolAnnotation.coordinateAssignments;
+        const assign = toolAnnotation?.coordinateAssignments;
         // Values are 1 indexed, but the location uses 0 indexing
-        location.Z = assign.Z.type === "layer" ? zIndex : assign.Z.value - 1;
+        location.Z =
+          assign?.Z?.type === "layer" ? zIndex : (assign?.Z?.value ?? 1) - 1;
         location.Time =
-          assign.Time.type === "layer" ? tIndex : assign.Time.value - 1;
+          assign?.Time?.type === "layer"
+            ? tIndex
+            : (assign?.Time?.value ?? 1) - 1;
       }
     }
     return { channel, location };

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1023,6 +1023,7 @@ export interface IWorkerLabels {
   interfaceCategory?: string;
   annotationShape?: AnnotationShape;
   description?: string;
+  advancedOptionsPanel?: string;
 }
 
 export interface IWorkerImageList {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1024,6 +1024,7 @@ export interface IWorkerLabels {
   annotationShape?: AnnotationShape;
   description?: string;
   advancedOptionsPanel?: string;
+  annotationConfigurationPanel?: string;
 }
 
 export interface IWorkerImageList {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1025,6 +1025,7 @@ export interface IWorkerLabels {
   description?: string;
   advancedOptionsPanel?: string;
   annotationConfigurationPanel?: string;
+  defaultToolName?: string;
 }
 
 export interface IWorkerImageList {

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -492,6 +492,13 @@ export class Properties extends VuexModule {
         }
       });
   }
+
+  get showAdvancedOptionsPanel() {
+    return (image: string) => {
+      const labels = this.workerImageList[image];
+      return labels ? labels.advancedOptionsPanel !== "False" : true;
+    };
+  }
 }
 
 export default getModule(Properties);

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -496,14 +496,14 @@ export class Properties extends VuexModule {
   get showAdvancedOptionsPanel() {
     return (image: string) => {
       const labels = this.workerImageList[image];
-      return labels ? labels.advancedOptionsPanel !== "False" : true;
+      return labels ? labels.advancedOptionsPanel?.toLowerCase() !== "false" : true;
     };
   }
 
   get showAnnotationConfigurationPanel() {
     return (image: string) => {
       const labels = this.workerImageList[image];
-      return labels ? labels.annotationConfigurationPanel !== "False" : true;
+      return labels ? labels.annotationConfigurationPanel?.toLowerCase() !== "false" : true;
     };
   }
 

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -506,6 +506,13 @@ export class Properties extends VuexModule {
       return labels ? labels.annotationConfigurationPanel !== "False" : true;
     };
   }
+
+  get defaultToolName() {
+    return (image: string) => {
+      const labels = this.workerImageList[image];
+      return labels ? labels.defaultToolName : null;
+    };
+  }
 }
 
 export default getModule(Properties);

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -496,14 +496,18 @@ export class Properties extends VuexModule {
   get showAdvancedOptionsPanel() {
     return (image: string) => {
       const labels = this.workerImageList[image];
-      return labels ? labels.advancedOptionsPanel?.toLowerCase() !== "false" : true;
+      return labels
+        ? labels.advancedOptionsPanel?.toLowerCase() !== "false"
+        : true;
     };
   }
 
   get showAnnotationConfigurationPanel() {
     return (image: string) => {
       const labels = this.workerImageList[image];
-      return labels ? labels.annotationConfigurationPanel?.toLowerCase() !== "false" : true;
+      return labels
+        ? labels.annotationConfigurationPanel?.toLowerCase() !== "false"
+        : true;
     };
   }
 

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -499,6 +499,13 @@ export class Properties extends VuexModule {
       return labels ? labels.advancedOptionsPanel !== "False" : true;
     };
   }
+
+  get showAnnotationConfigurationPanel() {
+    return (image: string) => {
+      const labels = this.workerImageList[image];
+      return labels ? labels.annotationConfigurationPanel !== "False" : true;
+    };
+  }
 }
 
 export default getModule(Properties);

--- a/src/tools/ToolEdition.vue
+++ b/src/tools/ToolEdition.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card>
     <v-card-title>
-      <span class="headline">Tool Edition:</span>
+      <span class="headline">Edit tool:</span>
       <v-text-field
         dense
         hide-details

--- a/src/tools/creation/ToolConfiguration.vue
+++ b/src/tools/creation/ToolConfiguration.vue
@@ -13,7 +13,7 @@
       </template>
     </v-container>
     <v-expansion-panels
-      v-if="advancedInternalTemplate.length > 0"
+      v-if="advancedInternalTemplate.length > 0 && showAdvancedPanel"
       v-model="advancedPanel"
     >
       <v-expansion-panel>
@@ -42,6 +42,7 @@
 <script lang="ts">
 import { Vue, Component, Watch, Prop } from "vue-property-decorator";
 import store from "@/store";
+import propertiesStore from "@/store/properties";
 import ToolConfigurationItem from "@/tools/creation/ToolConfigurationItem.vue";
 import AnnotationConfiguration from "@/tools/creation/templates/AnnotationConfiguration.vue";
 import TagAndLayerRestriction from "@/tools/creation/templates/TagAndLayerRestriction.vue";
@@ -55,6 +56,7 @@ import DockerImage from "@/tools/creation/templates/DockerImage.vue";
 // Creates a tool configuration interface based on the current selected template.
 export default class ToolConfiguration extends Vue {
   readonly store = store;
+  readonly propertiesStore = propertiesStore;
 
   @Prop()
   readonly value!: Record<string, any>;
@@ -229,6 +231,13 @@ export default class ToolConfiguration extends Vue {
         };
       }
     });
+  }
+
+  get showAdvancedPanel() {
+    const dockerImage = this.toolValues?.image?.image;
+    return dockerImage
+      ? this.propertiesStore.showAdvancedOptionsPanel(dockerImage)
+      : true;
   }
 }
 </script>

--- a/src/tools/creation/ToolConfiguration.vue
+++ b/src/tools/creation/ToolConfiguration.vue
@@ -3,6 +3,7 @@
     <v-container v-if="basicInternalTemplate.length > 0">
       <template v-for="(item, index) in basicInternalTemplate">
         <tool-configuration-item
+          v-if="shouldShowConfigurationItem(item)"
           :key="index"
           :item="item"
           :advanced="false"
@@ -24,6 +25,7 @@
           <v-container>
             <template v-for="(item, index) in advancedInternalTemplate">
               <tool-configuration-item
+                v-if="shouldShowConfigurationItem(item)"
                 :key="index"
                 :item="item"
                 :advanced="true"
@@ -237,6 +239,16 @@ export default class ToolConfiguration extends Vue {
     const dockerImage = this.toolValues?.image?.image;
     return dockerImage
       ? this.propertiesStore.showAdvancedOptionsPanel(dockerImage)
+      : true;
+  }
+
+  shouldShowConfigurationItem(item: any) {
+    if (item.type !== "annotation") {
+      return true;
+    }
+    const dockerImage = this.toolValues?.image?.image;
+    return dockerImage
+      ? this.propertiesStore.showAnnotationConfigurationPanel(dockerImage)
       : true;
   }
 }

--- a/src/tools/creation/ToolCreation.vue
+++ b/src/tools/creation/ToolCreation.vue
@@ -146,6 +146,13 @@ export default class ToolCreation extends Vue {
       return;
     }
     const toolNameStrings: string[] = [];
+    const dockerImage = this.toolValues?.image?.image;
+    if (dockerImage) {
+      const defaultToolName = this.propertyStore.defaultToolName(dockerImage);
+      if (defaultToolName) {
+        toolNameStrings.push(defaultToolName);
+      }
+    }
     if (this.toolValues?.annotation?.tags) {
       toolNameStrings.push(this.toolValues.annotation.tags.join(", "));
     }


### PR DESCRIPTION
Now, if you label an automated worker docker container like this:

```
LABEL isUPennContrastWorker="" \
      isAnnotationWorker="" \
      interfaceName="Connect to Nearest" \
      interfaceCategory="Connections" \
      description="Connects objects to each other based on distance" \
      advancedOptionsPanel="False" \
      annotationConfigurationPanel="False" \
      defaultToolName="Connect to Nearest"
```
it will turn off the Advanced Options Panel, configuration panel, and will auto-name with "Connect to Nearest".

Closes #784 