### PR TITLE
Allow no tag property creation

### DIFF
--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
@@ -276,7 +276,6 @@ export default class PropertyCreation extends Vue {
     this.dockerImage = null;
     this.originalName = "New Property";
     this.isNameGenerated = true;
-    this.computeUponCreation = true;
   }
 }
 </script>

--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
@@ -62,6 +62,11 @@
           </v-row>
         </template>
       </v-container>
+      <v-checkbox
+        v-model="computeUponCreation"
+        label="Compute upon creation"
+        class="mt-4"
+      />
       <div class="button-bar">
         <v-spacer></v-spacer>
         <v-btn class="mr-4" color="primary" @click="createProperty">
@@ -138,6 +143,8 @@ export default class PropertyCreation extends Vue {
   isNameGenerated = true;
 
   interfaceValues: IWorkerInterfaceValues = {};
+
+  computeUponCreation = true;
 
   get deduplicatedName() {
     // Find a name which is not already taken
@@ -255,6 +262,9 @@ export default class PropertyCreation extends Vue {
       })
       .then((property) => {
         this.propertyStore.togglePropertyPathVisibility([property.id]);
+        if (this.computeUponCreation) {
+          this.propertyStore.computeProperty(property);
+        }
       });
     this.reset();
   }
@@ -266,6 +276,7 @@ export default class PropertyCreation extends Vue {
     this.dockerImage = null;
     this.originalName = "New Property";
     this.isNameGenerated = true;
+    this.computeUponCreation = true;
   }
 }
 </script>

--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
@@ -28,10 +28,7 @@
           </v-col>
         </v-row>
       </v-container>
-      <v-container
-        class="elevation-3 mt-4"
-        v-if="filteringShape !== null && filteringTags.length > 0"
-      >
+      <v-container class="elevation-3 mt-4" v-if="filteringShape !== null">
         <div class="pb-4 subtitle-1">Measure this property:</div>
         <v-row>
           <v-col>
@@ -68,9 +65,9 @@
       <div class="button-bar">
         <v-spacer></v-spacer>
         <v-btn class="mr-4" color="primary" @click="createProperty">
-          SUBMIT
+          Create Property
         </v-btn>
-        <v-btn class="mr-4" color="warning" @click="reset">CANCEL</v-btn>
+        <v-btn class="mr-4" color="warning" @click="reset">Cancel</v-btn>
       </div>
     </v-card-text>
   </v-card>
@@ -161,7 +158,11 @@ export default class PropertyCreation extends Vue {
     if (this.filteringTags.length) {
       nameList.push(this.filteringTags.join(", "));
     } else {
-      nameList.push("No tag");
+      if (this.areTagsExclusive) {
+        nameList.push("No tag");
+      } else {
+        nameList.push("All");
+      }
     }
     if (this.dockerImage) {
       const imageInterfaceName =
@@ -238,11 +239,7 @@ export default class PropertyCreation extends Vue {
   }
 
   createProperty() {
-    if (
-      !this.dockerImage ||
-      !this.filteringShape ||
-      !this.filteringTags.length
-    ) {
+    if (!this.dockerImage || !this.filteringShape) {
       return;
     }
     this.propertyStore


### PR DESCRIPTION
This PR allows the user to create properties even if no tag is specified. This helps if you want to compute, say, area for all polygon objects at once.

Closes #788 
Closes #787 