### PR TITLE
Add delete unselected button

### DIFF
--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -11,6 +11,13 @@
             </v-btn>
           </v-col>
           <v-col class="pa-0 mx-1">
+            <v-btn block small @click.stop="deleteUnselected">
+              Delete Unselected
+            </v-btn>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col class="pa-0 mx-1">
             <v-dialog v-model="tagSelectedDialog" width="50%">
               <template v-slot:activator="{ on, attrs }">
                 <v-btn block small v-bind="attrs" v-on="on" @click.stop>
@@ -518,6 +525,10 @@ export default class AnnotationList extends Vue {
 
   deleteSelected() {
     this.annotationStore.deleteSelectedAnnotations();
+  }
+
+  deleteUnselected() {
+    this.annotationStore.deleteUnselectedAnnotations();
   }
 }
 </script>

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -559,6 +559,24 @@ export class Annotations extends VuexModule {
   }
 
   @Action
+  public async deleteUnselectedAnnotations() {
+    const unselectedIds = this.annotations
+      .filter(
+        (annotation) =>
+          !this.selectedAnnotations.some(
+            (selected) => selected.id === annotation.id,
+          ),
+      )
+      .map((annotation) => annotation.id);
+
+    if (unselectedIds.length === 0) {
+      return;
+    }
+
+    await this.deleteAnnotations(unselectedIds);
+  }
+
+  @Action
   public async updateAnnotationsPerId({
     annotationIds,
     editFunction,

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -541,6 +541,10 @@ export class Annotations extends VuexModule {
 
   @Action
   public async deleteAnnotations(ids: string[]) {
+    if (ids.length === 0) {
+      return;
+    }
+
     sync.setSaving(true);
     await this.annotationsAPI.deleteMultipleAnnotations(ids);
     sync.setSaving(false);
@@ -569,11 +573,7 @@ export class Annotations extends VuexModule {
       )
       .map((annotation) => annotation.id);
 
-    if (unselectedIds.length === 0) {
-      return;
-    }
-
-    await this.deleteAnnotations(unselectedIds);
+    this.deleteAnnotations(unselectedIds);
   }
 
   @Action


### PR DESCRIPTION
Allows you to delete all annotations that are not currently selected.

Closes #762 