### PR TITLE
Hide preview button

### DIFF
--- a/src/components/AnnotationWorkerMenu.vue
+++ b/src/components/AnnotationWorkerMenu.vue
@@ -35,7 +35,7 @@
           />
         </v-row>
         <v-row>
-          <v-btn @click="preview">Preview</v-btn>
+          <v-btn @click="preview" v-if="hasPreview">Preview</v-btn>
           <v-spacer></v-spacer>
           <v-btn @click="compute" :disabled="running">
             <v-progress-circular size="16" v-if="running" indeterminate />

--- a/src/components/AnnotationWorkerMenu.vue
+++ b/src/components/AnnotationWorkerMenu.vue
@@ -35,7 +35,7 @@
           />
         </v-row>
         <v-row>
-          <v-btn @click="preview">preview</v-btn>
+          <v-btn @click="preview">Preview</v-btn>
           <v-spacer></v-spacer>
           <v-btn @click="compute" :disabled="running">
             <v-progress-circular size="16" v-if="running" indeterminate />
@@ -46,6 +46,7 @@
         </v-row>
         <v-row>
           <v-checkbox
+            v-if="hasPreview"
             v-model="displayWorkerPreview"
             label="Display Previews"
           ></v-checkbox>
@@ -148,6 +149,7 @@ export default class AnnotationWorkerMenu extends Vue {
 
   @Watch("tool")
   async updateInterface(force?: boolean) {
+    this.propertyStore.fetchWorkerImageList(); // Required to update docker image labels
     if (
       (force || this.workerInterface === undefined) &&
       !this.fetchingWorkerInterface
@@ -158,6 +160,10 @@ export default class AnnotationWorkerMenu extends Vue {
         .finally();
       this.fetchingWorkerInterface = false;
     }
+  }
+
+  get hasPreview() {
+    return this.propertyStore.hasPreview(this.image);
   }
 }
 </script>

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1026,6 +1026,7 @@ export interface IWorkerLabels {
   advancedOptionsPanel?: string;
   annotationConfigurationPanel?: string;
   defaultToolName?: string;
+  hasPreview?: string;
 }
 
 export interface IWorkerImageList {

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -517,6 +517,13 @@ export class Properties extends VuexModule {
       return labels ? labels.defaultToolName : null;
     };
   }
+
+  get hasPreview() {
+    return (image: string) => {
+      const labels = this.workerImageList[image];
+      return labels ? labels.hasPreview?.toLowerCase() === "true" : false;
+    };
+  }
 }
 
 export default getModule(Properties);


### PR DESCRIPTION
Most workers do not have preview functionality, but the preview button is always showing. This PR hides the preview button unless the docker image has a "hasPreview" label set to True.