### PR TITLE
Handle worker error

### DIFF
--- a/devops/girder/annotation_client/annotation_client/utils.py
+++ b/devops/girder/annotation_client/annotation_client/utils.py
@@ -12,3 +12,17 @@ def sendProgress(progress, title, info):
     """
     print(json.dumps({"progress": progress, "title": title, "info": info}))
     sys.stdout.flush()
+
+
+def sendError(error_message, title="Error", info=None):
+    """
+    Send error message to the front end
+
+    :param str error_message: The error message to send
+    :param str title: Title for the error message
+    :param str info: Additional information to send
+    """
+    print(
+        json.dumps({"error": error_message, "title": title, "info": info})
+    )
+    sys.stdout.flush()

--- a/devops/girder/annotation_client/annotation_client/utils.py
+++ b/devops/girder/annotation_client/annotation_client/utils.py
@@ -14,6 +14,20 @@ def sendProgress(progress, title, info):
     sys.stdout.flush()
 
 
+def sendWarning(warning_message, title="Warning", info=None):
+    """
+    Send warning message to the front end
+
+    :param str warning_message: The warning message to send
+    :param str title: Title for the warning message
+    :param str info: Additional information to send
+    """
+    print(
+        json.dumps({"warning": warning_message, "title": title, "info": info, "type": "warning"})
+    )
+    sys.stdout.flush()
+
+
 def sendError(error_message, title="Error", info=None):
     """
     Send error message to the front end
@@ -23,6 +37,6 @@ def sendError(error_message, title="Error", info=None):
     :param str info: Additional information to send
     """
     print(
-        json.dumps({"error": error_message, "title": title, "info": info})
+        json.dumps({"error": error_message, "title": title, "info": info, "type": "error"})
     )
     sys.stdout.flush()

--- a/devops/girder/annotation_client/annotation_client/utils.py
+++ b/devops/girder/annotation_client/annotation_client/utils.py
@@ -22,9 +22,12 @@ def sendWarning(warning_message, title="Warning", info=None):
     :param str title: Title for the warning message
     :param str info: Additional information to send
     """
-    print(
-        json.dumps({"warning": warning_message, "title": title, "info": info, "type": "warning"})
-    )
+    print(json.dumps({
+        "warning": warning_message,
+        "title": title,
+        "info": info,
+        "type": "warning"
+    }))
     sys.stdout.flush()
 
 
@@ -36,7 +39,10 @@ def sendError(error_message, title="Error", info=None):
     :param str title: Title for the error message
     :param str info: Additional information to send
     """
-    print(
-        json.dumps({"error": error_message, "title": title, "info": info, "type": "error"})
-    )
+    print(json.dumps({
+        "error": error_message,
+        "title": title,
+        "info": info,
+        "type": "error"
+    }))
     sys.stdout.flush()

--- a/src/components/AnnotationWorkerMenu.vue
+++ b/src/components/AnnotationWorkerMenu.vue
@@ -22,7 +22,18 @@
             {{ progressInfo.info }}
           </v-progress-linear>
         </v-row>
-        <v-row v-for="(error, index) in filteredErrors" :key="index">
+        <v-row
+          v-for="(warning, index) in filteredWarnings"
+          :key="'warning-' + index"
+        >
+          <v-alert type="warning" dense class="mb-2">
+            <div class="error-main">
+              {{ warning.title }}: {{ warning.warning }}
+            </div>
+            <div v-if="warning.info" class="error-info">{{ warning.info }}</div>
+          </v-alert>
+        </v-row>
+        <v-row v-for="(error, index) in filteredErrors" :key="'error-' + index">
           <v-alert type="error" dense class="mb-2">
             <div class="error-main">{{ error.title }}: {{ error.error }}</div>
             <div v-if="error.info" class="error-info">{{ error.info }}</div>
@@ -69,10 +80,10 @@ import store from "@/store";
 import annotationsStore from "@/store/annotation";
 import {
   IProgressInfo,
-  IErrorInfo,
   IToolConfiguration,
   IWorkerInterfaceValues,
   IErrorInfoList,
+  MessageType,
 } from "@/store/model";
 import TagFilterEditor from "@/components/AnnotationBrowser/TagFilterEditor.vue";
 import LayerSelect from "@/components/LayerSelect.vue";
@@ -177,7 +188,15 @@ export default class AnnotationWorkerMenu extends Vue {
   }
 
   get filteredErrors() {
-    return this.errorInfo.errors.filter((error) => error.error);
+    return this.errorInfo.errors.filter(
+      (error) => error.error && error.type === MessageType.ERROR,
+    );
+  }
+
+  get filteredWarnings() {
+    return this.errorInfo.errors.filter(
+      (error) => error.warning && error.type === MessageType.WARNING,
+    );
   }
 }
 </script>
@@ -194,13 +213,14 @@ export default class AnnotationWorkerMenu extends Vue {
 
 .error-main {
   font-weight: 500;
-  max-width: 100px;
-  word-wrap: break-word; /* Ensures long words don't overflow */
+  max-width: 300px;
 }
 
 .error-info {
   font-size: 0.875em;
   margin-top: 4px;
+  max-width: 300px;
+  word-wrap: break-word; /* Ensures long words don't overflow */
   opacity: 0.9;
 }
 </style>

--- a/src/components/AnnotationWorkerMenu.vue
+++ b/src/components/AnnotationWorkerMenu.vue
@@ -24,8 +24,12 @@
         </v-row>
         <v-row v-if="errorInfo.error">
           <v-alert type="error" dense class="mb-2">
-            <div class="error-main">{{ errorInfo.title }}: {{ errorInfo.error }}</div>
-            <div v-if="errorInfo.info" class="error-info">{{ errorInfo.info }}</div>
+            <div class="error-main">
+              {{ errorInfo.title }}: {{ errorInfo.error }}
+            </div>
+            <div v-if="errorInfo.info" class="error-info">
+              {{ errorInfo.info }}
+            </div>
           </v-alert>
         </v-row>
         <v-row>

--- a/src/components/AnnotationWorkerMenu.vue
+++ b/src/components/AnnotationWorkerMenu.vue
@@ -63,6 +63,7 @@ import store from "@/store";
 import annotationsStore from "@/store/annotation";
 import {
   IProgressInfo,
+  IErrorInfo,
   IToolConfiguration,
   IWorkerInterfaceValues,
 } from "@/store/model";
@@ -87,7 +88,7 @@ export default class AnnotationWorkerMenu extends Vue {
   running: boolean = false;
   previousRunStatus: boolean | null = null;
   progressInfo: IProgressInfo = {};
-
+  errorInfo: IErrorInfo = {};
   interfaceValues: IWorkerInterfaceValues = {};
 
   @Prop()
@@ -128,6 +129,7 @@ export default class AnnotationWorkerMenu extends Vue {
       tool: this.tool,
       workerInterface: this.interfaceValues,
       progress: this.progressInfo,
+      error: this.errorInfo,
       callback: (success) => {
         this.running = false;
         this.previousRunStatus = success;

--- a/src/components/AnnotationWorkerMenu.vue
+++ b/src/components/AnnotationWorkerMenu.vue
@@ -22,6 +22,12 @@
             {{ progressInfo.info }}
           </v-progress-linear>
         </v-row>
+        <v-row v-if="errorInfo.error">
+          <v-alert type="error" dense class="mb-2">
+            <div class="error-main">{{ errorInfo.title }}: {{ errorInfo.error }}</div>
+            <div v-if="errorInfo.info" class="error-info">{{ errorInfo.info }}</div>
+          </v-alert>
+        </v-row>
         <v-row>
           <v-col>
             <v-subheader>Image: {{ tool.values.image.image }}</v-subheader>
@@ -179,5 +185,17 @@ export default class AnnotationWorkerMenu extends Vue {
 // Set min-height to 0 when loaded
 .loaded {
   min-height: 0;
+}
+
+.error-main {
+  font-weight: 500;
+  max-width: 100px;
+  word-wrap: break-word; /* Ensures long words don't overflow */
+}
+
+.error-info {
+  font-size: 0.875em;
+  margin-top: 4px;
+  opacity: 0.9;
 }
 </style>

--- a/src/components/AnnotationWorkerMenu.vue
+++ b/src/components/AnnotationWorkerMenu.vue
@@ -22,14 +22,10 @@
             {{ progressInfo.info }}
           </v-progress-linear>
         </v-row>
-        <v-row v-if="errorInfo.error">
+        <v-row v-for="(error, index) in filteredErrors" :key="index">
           <v-alert type="error" dense class="mb-2">
-            <div class="error-main">
-              {{ errorInfo.title }}: {{ errorInfo.error }}
-            </div>
-            <div v-if="errorInfo.info" class="error-info">
-              {{ errorInfo.info }}
-            </div>
+            <div class="error-main">{{ error.title }}: {{ error.error }}</div>
+            <div v-if="error.info" class="error-info">{{ error.info }}</div>
           </v-alert>
         </v-row>
         <v-row>
@@ -76,6 +72,7 @@ import {
   IErrorInfo,
   IToolConfiguration,
   IWorkerInterfaceValues,
+  IErrorInfoList,
 } from "@/store/model";
 import TagFilterEditor from "@/components/AnnotationBrowser/TagFilterEditor.vue";
 import LayerSelect from "@/components/LayerSelect.vue";
@@ -98,7 +95,7 @@ export default class AnnotationWorkerMenu extends Vue {
   running: boolean = false;
   previousRunStatus: boolean | null = null;
   progressInfo: IProgressInfo = {};
-  errorInfo: IErrorInfo = {};
+  errorInfo: IErrorInfoList = { errors: [] };
   interfaceValues: IWorkerInterfaceValues = {};
 
   @Prop()
@@ -177,6 +174,10 @@ export default class AnnotationWorkerMenu extends Vue {
 
   get hasPreview() {
     return this.propertyStore.hasPreview(this.image);
+  }
+
+  get filteredErrors() {
+    return this.errorInfo.errors.filter((error) => error.error);
   }
 }
 </script>

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -765,6 +765,9 @@ export class Annotations extends VuexModule {
     }
     const datasetId = main.dataset.id;
 
+    // Clear error while maintaining reactivity
+    Object.keys(error).forEach((key) => Vue.set(error, key, undefined));
+
     const { location, channel } =
       await this.getAnnotationLocationFromTool(tool);
     const tile = { XY: main.xy, Z: main.z, Time: main.time };
@@ -795,6 +798,7 @@ export class Annotations extends VuexModule {
     };
     jobs.addJob(computeJob).then((success: boolean) => {
       this.fetchAnnotations();
+      // TODO: We may also want to fetch connections and properties here, depending on flags set in the worker image
       callback(success);
     });
     return computeJob;

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -9,7 +9,10 @@ import store from "./root";
 
 import main from "./index";
 import sync from "./sync";
-import jobs, { createProgressEventCallback, createErrorEventCallback } from "./jobs";
+import jobs, {
+  createProgressEventCallback,
+  createErrorEventCallback,
+} from "./jobs";
 
 import {
   IAnnotation,

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -9,7 +9,7 @@ import store from "./root";
 
 import main from "./index";
 import sync from "./sync";
-import jobs, { createProgressEventCallback } from "./jobs";
+import jobs, { createProgressEventCallback, createErrorEventCallback } from "./jobs";
 
 import {
   IAnnotation,
@@ -21,6 +21,7 @@ import {
   IWorkerInterfaceValues,
   IAnnotationComputeJob,
   IProgressInfo,
+  IErrorInfo,
 } from "./model";
 
 import Vue, { markRaw } from "vue";
@@ -750,11 +751,13 @@ export class Annotations extends VuexModule {
     tool,
     workerInterface,
     progress,
+    error,
     callback,
   }: {
     tool: IToolConfiguration;
     workerInterface: IWorkerInterfaceValues;
     progress: IProgressInfo;
+    error: IErrorInfo;
     callback: (success: boolean) => void;
   }) {
     if (!main.dataset || !main.configuration) {
@@ -788,6 +791,7 @@ export class Annotations extends VuexModule {
       jobId,
       datasetId,
       eventCallback: createProgressEventCallback(progress),
+      errorCallback: createErrorEventCallback(error),
     };
     jobs.addJob(computeJob).then((success: boolean) => {
       this.fetchAnnotations();

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -24,7 +24,6 @@ import {
   IWorkerInterfaceValues,
   IAnnotationComputeJob,
   IProgressInfo,
-  IErrorInfo,
   IErrorInfoList,
 } from "./model";
 

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -25,6 +25,7 @@ import {
   IAnnotationComputeJob,
   IProgressInfo,
   IErrorInfo,
+  IErrorInfoList,
 } from "./model";
 
 import Vue, { markRaw } from "vue";
@@ -760,7 +761,7 @@ export class Annotations extends VuexModule {
     tool: IToolConfiguration;
     workerInterface: IWorkerInterfaceValues;
     progress: IProgressInfo;
-    error: IErrorInfo;
+    error: IErrorInfoList;
     callback: (success: boolean) => void;
   }) {
     if (!main.dataset || !main.configuration) {
@@ -768,8 +769,8 @@ export class Annotations extends VuexModule {
     }
     const datasetId = main.dataset.id;
 
-    // Clear error while maintaining reactivity
-    Object.keys(error).forEach((key) => Vue.set(error, key, undefined));
+    // Clear errors while maintaining reactivity
+    Vue.set(error, "errors", []);
 
     const { location, channel } =
       await this.getAnnotationLocationFromTool(tool);

--- a/src/store/jobs.ts
+++ b/src/store/jobs.ts
@@ -53,7 +53,7 @@ export function createProgressEventCallback(progressObject: IProgressInfo) {
   };
 }
 
-export function createErrorEventCallback(errorObject: IErrorInfo) {
+export function createErrorEventCallback(errorObject: IErrorInfoList) {
   return (jobData: IJobEventData) => {
     const text = jobData.text;
     if (!text || typeof text !== "string") {
@@ -70,10 +70,14 @@ export function createErrorEventCallback(errorObject: IErrorInfo) {
           continue;
         }
         if (error.error) {
-          // Update the errorObject or UI as needed
-          Vue.set(errorObject, "title", error.title);
-          Vue.set(errorObject, "error", error.error);
-          Vue.set(errorObject, "info", error.info);
+          // Create new error info object
+          const newError: IErrorInfo = {
+            title: error.title,
+            error: error.error,
+            info: error.info,
+          };
+          // Add to errors array while maintaining reactivity
+          Vue.set(errorObject.errors, errorObject.errors.length, newError);
         }
       } catch {}
     }

--- a/src/store/jobs.ts
+++ b/src/store/jobs.ts
@@ -73,6 +73,9 @@ export function createErrorEventCallback(errorObject: IErrorInfo) {
           // Handle the error message
           console.log(`Error: ${error.title} - ${error.error} - ${error.info}`);
           // Update the errorObject or UI as needed
+          Vue.set(errorObject, "title", error.title);
+          Vue.set(errorObject, "error", error.error);
+          Vue.set(errorObject, "info", error.info);
         }
       } catch {}
     }

--- a/src/store/jobs.ts
+++ b/src/store/jobs.ts
@@ -70,8 +70,6 @@ export function createErrorEventCallback(errorObject: IErrorInfo) {
           continue;
         }
         if (error.error) {
-          // Handle the error message
-          console.log(`Error: ${error.title} - ${error.error} - ${error.info}`);
           // Update the errorObject or UI as needed
           Vue.set(errorObject, "title", error.title);
           Vue.set(errorObject, "error", error.error);

--- a/src/store/jobs.ts
+++ b/src/store/jobs.ts
@@ -11,6 +11,7 @@ import Vue from "vue";
 import {
   IComputeJob,
   IErrorInfo,
+  IErrorInfoList,
   IJobEventData,
   IProgressInfo,
   MessageType,

--- a/src/store/jobs.ts
+++ b/src/store/jobs.ts
@@ -8,7 +8,13 @@ import {
 import store from "./root";
 import Vue from "vue";
 
-import { IComputeJob, IErrorInfo, IJobEventData, IProgressInfo } from "./model";
+import {
+  IComputeJob,
+  IErrorInfo,
+  IJobEventData,
+  IProgressInfo,
+  MessageType,
+} from "./model";
 
 import main from "./index";
 
@@ -69,12 +75,16 @@ export function createErrorEventCallback(errorObject: IErrorInfoList) {
         if (error.progress) {
           continue;
         }
-        if (error.error) {
+        if (error.error || error.warning) {
           // Create new error info object
           const newError: IErrorInfo = {
             title: error.title,
             error: error.error,
+            warning: error.warning,
             info: error.info,
+            type:
+              error.type ||
+              (error.error ? MessageType.ERROR : MessageType.WARNING),
           };
           // Add to errors array while maintaining reactivity
           Vue.set(errorObject.errors, errorObject.errors.length, newError);

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1175,10 +1175,17 @@ export interface IProgressInfo {
   progress?: number;
 }
 
+export enum MessageType {
+  ERROR = "error",
+  WARNING = "warning",
+}
+
 export interface IErrorInfo {
   title?: string;
   error?: string;
+  warning?: string;
   info?: string;
+  type?: MessageType;
 }
 
 export interface IErrorInfoList {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1175,6 +1175,12 @@ export interface IProgressInfo {
   progress?: number;
 }
 
+export interface IErrorInfo {
+  title?: string;
+  error?: string;
+  info?: string;
+}
+
 export interface ICameraInfo {
   center: IGeoJSPosition;
   zoom: number;
@@ -1191,6 +1197,7 @@ export interface IComputeJobBase {
   jobId: string;
   datasetId: string | null;
   eventCallback?: (data: IJobEventData) => void;
+  errorCallback?: (data: IJobEventData) => void;
 }
 export interface IAnnotationComputeJob extends IComputeJobBase {
   toolId: string;

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1181,6 +1181,10 @@ export interface IErrorInfo {
   info?: string;
 }
 
+export interface IErrorInfoList {
+  errors: IErrorInfo[];
+}
+
 export interface ICameraInfo {
   center: IGeoJSPosition;
   zoom: number;


### PR DESCRIPTION
Added an error alert. It allows you to send an error using sendError just like sendProgress. This way, the worker can communicate an error to the user. We may also want to send warnings to the user through the same interface, perhaps by using a warning flag or something.