### PR TITLE
Bump geojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "eslint": "8.56.0",
     "eslint-plugin-prettier": "^5.1.2",
     "eslint-plugin-vue": "^9.19.2",
-    "geojs": "^1.12.4",
+    "geojs": "^1.12.6",
     "jsdom": "^24.0.0",
     "prettier": "^3.1.1",
     "pug": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
         specifier: ^9.19.2
         version: 9.20.1(eslint@8.56.0)
       geojs:
-        specifier: ^1.12.4
-        version: 1.12.4(@babel/preset-env@7.23.8(@babel/core@7.23.7))(autoprefixer@10.4.16(postcss@8.4.33))(webpack@5.89.0)(wslink@1.12.4)
+        specifier: ^1.12.6
+        version: 1.12.6(@babel/preset-env@7.23.8(@babel/core@7.23.7))(autoprefixer@10.4.16(postcss@8.4.33))(webpack@5.89.0)(wslink@1.12.4)
       jsdom:
         specifier: ^24.0.0
         version: 24.0.0(canvas@2.11.2)
@@ -2416,8 +2416,8 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  geojs@1.12.4:
-    resolution: {integrity: sha512-A+0HrNWXn6vPgltUQa0OPM7z63Z6S2y+C17BDjKzCF9iQq7U+co0kXuXzirpFQVaPahHA6nbgYo9EdkW7PyZgQ==}
+  geojs@1.12.6:
+    resolution: {integrity: sha512-hNjagdm1MMm+2zx03RksJ71Vsd10lWhCvuTBCCaHQe55+p1A/f02SdIFKCD1U3VGpNKlPvQvYsmqfFxM4KV82g==}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -6673,7 +6673,7 @@ snapshots:
   gensync@1.0.0-beta.2:
     optional: true
 
-  geojs@1.12.4(@babel/preset-env@7.23.8(@babel/core@7.23.7))(autoprefixer@10.4.16(postcss@8.4.33))(webpack@5.89.0)(wslink@1.12.4):
+  geojs@1.12.6(@babel/preset-env@7.23.8(@babel/core@7.23.7))(autoprefixer@10.4.16(postcss@8.4.33))(webpack@5.89.0)(wslink@1.12.4):
     dependencies:
       canvas: 2.11.2
       color-name: 2.0.0


### PR DESCRIPTION
Bump geojs to 1.12.6. Increased performance for large numbers of annotations.